### PR TITLE
add base-uri to deployment

### DIFF
--- a/code/src/sixsq/nuvla/server/resources/deployment.clj
+++ b/code/src/sixsq/nuvla/server/resources/deployment.clj
@@ -57,7 +57,7 @@
 
 
 (defmethod crud/add resource-type
-  [{:keys [identity body] :as request}]
+  [{:keys [identity body base-uri] :as request}]
 
   (a/can-modify? {:acl collection-acl} request)
 
@@ -65,7 +65,8 @@
                        (assoc :resource-type resource-type)
                        (assoc :state "CREATED")
                        (assoc :module (deployment-utils/resolve-module (:module body) identity))
-                       (assoc :api-credentials (deployment-utils/generate-api-key-secret request)))
+                       (assoc :api-credentials (deployment-utils/generate-api-key-secret request))
+                       (assoc :api-endpoint base-uri))
 
         create-response (add-impl (assoc request :body deployment))
 

--- a/code/src/sixsq/nuvla/server/resources/spec/deployment.cljc
+++ b/code/src/sixsq/nuvla/server/resources/spec/deployment.cljc
@@ -84,24 +84,44 @@
 
 
 (s/def ::api-credentials
-  (-> (st/spec (su/only-keys :req-un [::api-key ::api-secret]))
-      (assoc :name "api-credentials"
-             :json-schema/name "api-credentials"
-             :json-schema/type "map"
-             :json-schema/providerMandatory false
-             :json-schema/consumerMandatory false
-             :json-schema/mutable true
-             :json-schema/consumerWritable true
-             :json-schema/indexed false
+       (-> (st/spec (su/only-keys :req-un [::api-key ::api-secret]))
+           (assoc :name "api-credentials"
+                  :json-schema/name "api-credentials"
+                  :json-schema/type "map"
+                  :json-schema/providerMandatory false
+                  :json-schema/consumerMandatory false
+                  :json-schema/mutable true
+                  :json-schema/consumerWritable true
+                  :json-schema/indexed false
 
-             :json-schema/displayName "Nuvla credentials"
-             :json-schema/description "Nuvla deployment API credentials"
-             :json-schema/help "Nuvla deployment API credentials"
-             :json-schema/group "data"
-             :json-schema/category "data"
-             :json-schema/order 20
-             :json-schema/hidden false
-             :json-schema/sensitive false)))
+                  :json-schema/displayName "Nuvla credentials"
+                  :json-schema/description "Nuvla deployment API credentials"
+                  :json-schema/help "Nuvla deployment API credentials"
+                  :json-schema/group "data"
+                  :json-schema/category "data"
+                  :json-schema/order 20
+                  :json-schema/hidden false
+                  :json-schema/sensitive false)))
+
+(s/def ::api-endpoint
+       (-> (st/spec ::cimi-core/nonblank-string)
+           (assoc :name "api-endpoint"
+                  :json-schema/name "api-endpoint"
+                  :json-schema/type "string"
+                  :json-schema/providerMandatory true
+                  :json-schema/consumerMandatory false
+                  :json-schema/mutable false
+                  :json-schema/consumerWritable false
+                  :json-schema/indexed false
+
+                  :json-schema/displayName "Nuvla endpoint"
+                  :json-schema/description "Nuvla endpoint"
+                  :json-schema/help "Nuvla endpoint"
+                  :json-schema/group "data"
+                  :json-schema/category "data"
+                  :json-schema/order 22
+                  :json-schema/hidden false
+                  :json-schema/sensitive false)))
 
 (s/def ::credential-id ::cimi-core/nonblank-string)
 
@@ -174,7 +194,8 @@
   (su/merge-keys-specs [cimi-common/common-attrs
                         {:req-un [::module
                                   ::state
-                                  ::api-credentials]
+                                  ::api-credentials
+                                  ::api-endpoint]
                          :opt-un [::credential-id
                                   ::infrastructure-service-id
                                   ::data-objects

--- a/code/test/sixsq/nuvla/server/resources/spec/deployment_test.cljc
+++ b/code/test/sixsq/nuvla/server/resources/spec/deployment_test.cljc
@@ -25,6 +25,7 @@
 
                        :api-credentials           {:api-key    "credential/uuid"
                                                    :api-secret "api secret"}
+                       :api-endpoint              "http://blah.example.com"
 
                        :credential-id             "credential/my-cloud-credential"
                        :infrastructure-service-id "infrastructure-service/my-service"
@@ -46,7 +47,7 @@
   (stu/is-invalid ::ds/deployment (assoc valid-deployment :data-records {"BAD_ID" nil}))
 
   ;; required attributes
-  (doseq [k #{:id :resource-type :created :updated :acl :state :module}]
+  (doseq [k #{:id :resource-type :created :updated :acl :state :module :api-credentials :api-endpoint}]
     (stu/is-invalid ::ds/deployment (dissoc valid-deployment k)))
 
   ;; optional attributes


### PR DESCRIPTION
Add base-uri to deployment so that deployed containers can use the correct endpoint for the API.