### PR TITLE
update user/group resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+  - Update the default user resource ACL to allow all user to see metadata
+  - Related to the above, do not rewrite the ACL in the post-add for user resources
+  - Fix a regex problem with dates that have only one digit
+  - Add the id field to full text searches
+  - Add a default value for :name for user resources if not provided explicitly (defaults to username then email)
+  - Allow users to search the group collection and provide the view-meta rights for all users
+
 ## [2.0.0] - 2019-04-29
 
 Initial, functionally-complete release. 

--- a/code/src/sixsq/nuvla/server/resources/group.clj
+++ b/code/src/sixsq/nuvla/server/resources/group.clj
@@ -26,7 +26,7 @@ that start with 'nuvla-' are reserved for the server.
 (def ^:const create-type (u/ns->create-type *ns*))
 
 
-(def collection-acl {:query ["group/nuvla-admin"]
+(def collection-acl {:query ["group/nuvla-user"]
                      :add   ["group/nuvla-admin"]})
 
 
@@ -54,9 +54,11 @@ that start with 'nuvla-' are reserved for the server.
 ;; multimethod for ACLs
 ;;
 
+;; forces update of acl to have admin as owner and all users can view metadata
 (defmethod crud/add-acl resource-type
   [resource request]
-  (a/add-acl (dissoc resource :acl) request))
+  (assoc resource :acl {:owners ["group/nuvla-admin"]
+                        :view-meta ["group/nuvla-user"]}))
 
 
 ;;

--- a/code/src/sixsq/nuvla/server/resources/spec/common.cljc
+++ b/code/src/sixsq/nuvla/server/resources/spec/common.cljc
@@ -33,6 +33,7 @@
              :json-schema/description "unique resource identifier"
              :json-schema/section "meta"
 
+             :json-schema/fulltext true
              :json-schema/server-managed true
              :json-schema/editable false
              :json-schema/order 0)))

--- a/code/src/sixsq/nuvla/server/resources/user.clj
+++ b/code/src/sixsq/nuvla/server/resources/user.clj
@@ -23,7 +23,8 @@ requires a template. All the SCRUD actions follow the standard CIMI patterns.
     [sixsq.nuvla.server.resources.user-identifier :as user-identifier]
     [sixsq.nuvla.server.resources.user-template :as p]
     [sixsq.nuvla.server.resources.user-template-username-password :as username-password]
-    [sixsq.nuvla.server.util.log :as logu]))
+    [sixsq.nuvla.server.util.log :as logu]
+    [sixsq.nuvla.auth.utils.acl :as acl-utils]))
 
 
 (def ^:const resource-type (u/ns->type *ns*))
@@ -83,8 +84,10 @@ requires a template. All the SCRUD actions follow the standard CIMI patterns.
 ;;
 
 (defmethod crud/add-acl resource-type
-  [resource request]
-  (assoc resource :acl {:owners ["group/nuvla-admin"]}))
+  [{:keys [id] :as resource} request]
+  (assoc resource :acl {:owners ["group/nuvla-admin"]
+                        :view-meta ["group/nuvla-user"]
+                        :edit-acl [id]}))
 
 ;;
 ;; template processing

--- a/code/src/sixsq/nuvla/server/resources/user/password.clj
+++ b/code/src/sixsq/nuvla/server/resources/user/password.clj
@@ -6,10 +6,11 @@
 (defn create-user-map
   "Transforms template into a user resource. Strips the method attribute and
    updates the resource-type."
-  [{:keys [name description tags method] :as resource}]
-  (cond-> {:resource-type p/resource-type
-           :method        method
-           :state         "NEW"}
-          name (assoc :name name)
-          description (assoc :description description)
-          tags (assoc :tags tags)))
+  [{:keys [name description tags method username email] :as resource}]
+  (let [name-attr (or name username email)]
+    (cond-> {:resource-type p/resource-type
+             :method        method
+             :state         "NEW"}
+            name-attr (assoc :name name-attr)
+            description (assoc :description description)
+            tags (assoc :tags tags))))

--- a/code/src/sixsq/nuvla/server/resources/user/utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/user/utils.clj
@@ -95,9 +95,7 @@
                           (create-email user-id))]
 
     (update-user user-id (cond-> {:id                  user-id
-                                  :credential-password credential-id
-                                  :acl                 {:owners   ["group/nuvla-admin"]
-                                                        :edit-acl [user-id]}}
+                                  :credential-password credential-id}
                                  email-id (assoc :email email-id)))
 
     (when email

--- a/code/test/sixsq/nuvla/auth/utils/timestamp_test.clj
+++ b/code/test/sixsq/nuvla/auth/utils/timestamp_test.clj
@@ -6,7 +6,7 @@
     [sixsq.nuvla.auth.utils.timestamp :as t]))
 
 
-(def rfc822-like-pattern #"\w\w\w, \d\d \w\w\w \d\d\d\d \d\d:\d\d:\d\d GMT")
+(def rfc822-like-pattern #"\w\w\w, \d{1,2} \w\w\w \d\d\d\d \d\d:\d\d:\d\d GMT")
 
 
 (def iso8601-like-pattern #"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(\.\d+)?(([\+-]\d\d:\d\d)|Z)")

--- a/code/test/sixsq/nuvla/server/resources/user_email_password_lifecycle_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/user_email_password_lifecycle_test.clj
@@ -71,12 +71,12 @@
                                                                   :password plaintext-password
                                                                   :username "alice"
                                                                   :email "alice@example.org"))}
-            href-create {:name        name-attr
+            href-create {;:name        name-attr
                          :description description-attr
                          :tags        tags-attr
                          :template    {:href     href
                                        :password plaintext-password
-                                       :username "user/jane"
+                                       ;:username "user/jane"
                                        :email    "jane@example.org"}}
 
             href-create-alt (assoc-in href-create [:template :username] uname-alt)
@@ -140,6 +140,10 @@
                                                     (request (str p/service-context user-id))
                                                     (ltu/body->edn)
                                                     (get-in [:response :body]))]
+
+            ;; verify name attribute (should default to username if no :name)
+            (is (= "jane@example.org" (:name user)))
+
             ; credential password is created and visible by the created user
             (-> session-created-user
                 (request (str p/service-context credential-id))
@@ -151,12 +155,12 @@
                 (ltu/body->edn)
                 (ltu/is-status 403))
 
-            ; 2 identifier are visible for the created user one for email and another one for the username
+            ; 1 identifier is visible for the created user one for email (username was not provided)
             (-> session-created-user
                 (request (str p/service-context user-identifier/resource-type))
                 (ltu/body->edn)
                 (ltu/is-status 200)
-                (ltu/is-count 2))
+                (ltu/is-count 1))
 
             ; one email is visible for the user
             (-> session-created-user

--- a/code/test/sixsq/nuvla/server/resources/user_username_password_lifecycle_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/user_username_password_lifecycle_test.clj
@@ -122,6 +122,17 @@
                                                        (ltu/is-status 200)
                                                        (get-in [:response :body]))]
 
+        ;; verify the ACL of the user
+        (let [user-acl (:acl user)]
+          (is (some #{"group/nuvla-admin"} (:owners user-acl)))
+          (is (some #{"group/nuvla-user"} (:view-meta user-acl)))
+
+          ;; user should have all rights
+          (doseq [right [:view-meta :view-data :view-acl
+                         :edit-meta :edit-data :edit-acl
+                         :manage :delete]]
+            (is (some #{user-id} (right user-acl)))))
+
         ; credential password is created and visible by the created user
         (-> session-created-user
             (request (str p/service-context credential-password))

--- a/code/test/sixsq/nuvla/server/resources/user_username_password_lifecycle_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/user_username_password_lifecycle_test.clj
@@ -53,8 +53,7 @@
           no-href-create {:template (ltu/strip-unwanted-attrs (assoc template
                                                                 :password plaintext-password
                                                                 :username "alice"))}
-          href-create {:name        name-attr
-                       :description description-attr
+          href-create {:description description-attr
                        :tags        tags-attr
                        :template    {:href     template-href
                                      :password plaintext-password
@@ -132,6 +131,9 @@
                          :edit-meta :edit-data :edit-acl
                          :manage :delete]]
             (is (some #{user-id} (right user-acl)))))
+
+        ;; verify name attribute (should default to username)
+        (is ("user/jane" (:name user)))
 
         ; credential password is created and visible by the created user
         (-> session-created-user

--- a/code/test/sixsq/nuvla/server/resources/user_username_password_lifecycle_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/user_username_password_lifecycle_test.clj
@@ -133,7 +133,7 @@
             (is (some #{user-id} (right user-acl)))))
 
         ;; verify name attribute (should default to username)
-        (is ("user/jane" (:name user)))
+        (is (= "user/jane" (:name user)))
 
         ; credential password is created and visible by the created user
         (-> session-created-user

--- a/code/test/sixsq/nuvla/server/util/es_mapping_test.cljc
+++ b/code/test/sixsq/nuvla/server/util/es_mapping_test.cljc
@@ -34,7 +34,7 @@
 
                        ::common/tags {:type "keyword", :copy_to "fulltext"}
 
-                       ::common/id {:type "keyword"}
+                       ::common/id {:type "keyword", :copy_to "fulltext"}
                        ::common/resource-type {:type "keyword"}
                        ::common/created {:type "date", :format "strict_date_optional_time||epoch_millis"}
                        ::common/updated {:type "date", :format "strict_date_optional_time||epoch_millis"}


### PR DESCRIPTION
The following changes have been made:

 - Update the default user resource ACL to allow all user to see metadata
 - Related to the above, do not rewrite the ACL in the post-add for user resources
 - Fix a regex problem with dates that have only one digit
 - Add the id field to full text searches
 - Add a default value for `:name` for user resources if not provided explicitly (defaults to username then email)
 - Allow users to search the group collection and provide the view-meta rights for all users
