### PR TITLE
Nuvlabox record secret generation

### DIFF
--- a/code/src/sixsq/nuvla/server/resources/credential.clj
+++ b/code/src/sixsq/nuvla/server/resources/credential.clj
@@ -185,6 +185,16 @@ CredentialTemplate resource.
         (update-in [:body] merge create-resp))))
 
 
+(defn create-credential
+  "Utility to facilitate creating a new credential resource. The returned value
+   is the standard 'add' response for the request."
+  [credential-template identity]
+  (let [credential-request {:params      {:resource-name resource-type}
+                            :nuvla/authn identity
+                            :body        credential-template}]
+    (crud/add credential-request)))
+
+
 (defmulti special-edit dispatch-conversion)
 
 

--- a/code/src/sixsq/nuvla/server/resources/credential_api_key.clj
+++ b/code/src/sixsq/nuvla/server/resources/credential_api_key.clj
@@ -73,13 +73,14 @@ secret, so you must capture and save the plain text secret from this response!
 ;; provides attributes about the key.
 ;;
 (defmethod p/tpl->credential tpl/credential-type
-  [{:keys [type method ttl]} request]
+  [{:keys [type method ttl acl]} request]
   (let [[secret-key digest] (key-utils/generate)
         resource (cond-> {:resource-type p/resource-type
                           :type          type
                           :method        method
                           :digest        digest
-                          :claims        (extract-claims request)}
+                          :claims        (extract-claims request)
+                          :acl           acl}
                          (valid-ttl? ttl) (assoc :expiry (u/ttl->timestamp ttl)))]
     [{:secret-key secret-key} resource]))
 

--- a/code/src/sixsq/nuvla/server/resources/credential_api_key.clj
+++ b/code/src/sixsq/nuvla/server/resources/credential_api_key.clj
@@ -61,7 +61,7 @@ secret, so you must capture and save the plain text secret from this response!
   (vec (remove #(re-matches #"^session/.*" %) roles)))
 
 (defn extract-claims [request]
-  (let [{:keys [:user-id :claims]} (auth/current-authentication request)
+  (let [{:keys [user-id claims]} (auth/current-authentication request)
         roles (strip-session-role claims)]
     (cond-> {:identity user-id}
             (seq roles) (assoc :roles (vec roles)))))
@@ -81,7 +81,7 @@ secret, so you must capture and save the plain text secret from this response!
                           :digest        digest
                           :claims        (extract-claims request)}
                          (valid-ttl? ttl) (assoc :expiry (u/ttl->timestamp ttl)))]
-    [{:secretKey secret-key} resource]))
+    [{:secret-key secret-key} resource]))
 
 ;;
 ;; multimethods for validation

--- a/code/src/sixsq/nuvla/server/resources/nuvlabox_record.clj
+++ b/code/src/sixsq/nuvla/server/resources/nuvlabox_record.clj
@@ -9,7 +9,8 @@
     [sixsq.nuvla.server.resources.common.utils :as u]
     [sixsq.nuvla.server.resources.nuvlabox.utils :as utils]
     [sixsq.nuvla.server.resources.spec.nuvlabox-record :as nuvlabox-record]
-    [sixsq.nuvla.server.util.log :as logu]))
+    [sixsq.nuvla.server.util.log :as logu]
+    [sixsq.nuvla.server.util.response :as r]))
 
 
 (def ^:const resource-type (u/ns->type *ns*))
@@ -139,10 +140,14 @@
 (defmethod crud/do-action [resource-type "activate"]
   [{{uuid :uuid} :params :as request}]
   (try
-    (let [id (str resource-type "/" uuid)
-          nuvlabox (db/retrieve id request)
-          nuvlabox-activated (activate nuvlabox)]
-      (db/edit nuvlabox-activated request))
+    (let [id                 (str resource-type "/" uuid)
+          nuvlabox           (db/retrieve id request)
+          nuvlabox-activated (activate nuvlabox)
+          api-secret-info    (utils/create-nuvlabox-api-key nuvlabox-activated)]
+
+      (db/edit nuvlabox-activated request)
+
+      (r/json-response api-secret-info))
     (catch Exception e
       (or (ex-data e) (throw e)))))
 

--- a/code/test/sixsq/nuvla/server/resources/credential_api_key_lifecycle_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/credential_api_key_lifecycle_test.clj
@@ -107,7 +107,7 @@
                    (ltu/body->edn)
                    (ltu/is-status 201))
           id (get-in resp [:response :body :resource-id])
-          secret-key (get-in resp [:response :body :secretKey])
+          secret-key (get-in resp [:response :body :secret-key])
           uri (-> resp
                   (ltu/location))
           abs-uri (str p/service-context uri)]
@@ -158,7 +158,7 @@
                    (ltu/body->edn)
                    (ltu/is-status 201))
           id (get-in resp [:response :body :resource-id])
-          secret-key (get-in resp [:response :body :secretKey])
+          secret-key (get-in resp [:response :body :secret-key])
           uri (-> resp
                   (ltu/location))
           abs-uri (str p/service-context uri)]
@@ -205,7 +205,7 @@
                    (ltu/body->edn)
                    (ltu/is-status 201))
           id (get-in resp [:response :body :resource-id])
-          secret-key (get-in resp [:response :body :secretKey])
+          secret-key (get-in resp [:response :body :secret-key])
           uri (-> resp
                   (ltu/location))
           abs-uri (str p/service-context uri)]

--- a/code/test/sixsq/nuvla/server/resources/nuvlabox_record_0_lifecycle_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/nuvlabox_record_0_lifecycle_test.clj
@@ -35,8 +35,8 @@
 
 (def valid-nuvlabox {:created          timestamp
                      :updated          timestamp
-                     :acl              {:owners   ["group/nuvla-admin"]
-                                        :view-acl ["group/nuvla-user"]}
+                     :acl              {:owners   ["group/nuvla-admin" "user/alpha"]
+                                        :view-acl ["user/jane"]}
 
                      :version          0
 
@@ -54,13 +54,13 @@
 
 
 (deftest lifecycle
-  (let [session (-> (ltu/ring-app)
-                    session
-                    (content-type "application/json"))
+  (let [session       (-> (ltu/ring-app)
+                          session
+                          (content-type "application/json"))
         session-admin (header session authn-info-header "user/super group/nuvla-admin group/nuvla-user group/nuvla-anon")
 
-        session-jane (header session authn-info-header "user/jane group/nuvla-user group/nuvla-anon")
-        session-anon (header session authn-info-header "unknown group/nuvla-anon")]
+        session-jane  (header session authn-info-header "user/jane group/nuvla-user group/nuvla-anon")
+        session-anon  (header session authn-info-header "unknown group/nuvla-anon")]
 
     ;; admin and deployer collection query should succeed but be empty (no  records created yet)
     (-> session-admin
@@ -144,17 +144,17 @@
         (ltu/is-status 201))
 
     ;; create & actions
-    (let [resp-admin (-> session-admin
-                         (request base-uri
-                                  :request-method :post
-                                  :body (json/write-str (assoc valid-nuvlabox :mac-address "01:bb:cc:dd:ee:ff")))
-                         (ltu/body->edn)
-                         (ltu/is-status 201))
+    (let [resp-admin     (-> session-admin
+                             (request base-uri
+                                      :request-method :post
+                                      :body (json/write-str (assoc valid-nuvlabox :mac-address "01:bb:cc:dd:ee:ff")))
+                             (ltu/body->edn)
+                             (ltu/is-status 201))
 
 
-          id-nuvlabox (get-in resp-admin [:response :body :resource-id])
+          id-nuvlabox    (get-in resp-admin [:response :body :resource-id])
           location-admin (str p/service-context (-> resp-admin ltu/location))
-          uri-nuvlabox (str p/service-context id-nuvlabox)]
+          uri-nuvlabox   (str p/service-context id-nuvlabox)]
 
       ;; id is a UUID now, not the MAC address
       (is (not= (str nb/resource-type "/01bbccddeeff") id-nuvlabox))
@@ -162,40 +162,49 @@
       (is (= location-admin uri-nuvlabox))
 
       ;; user should be able to see the resource and recover activation URL
-      (let [activate-op (-> session-jane
-                            (request uri-nuvlabox)
-                            (ltu/body->edn)
-                            (ltu/is-status 200)
-                            (ltu/is-operation-absent "delete")
-                            (ltu/is-operation-absent "edit")
-                            (ltu/is-operation-present "activate")
-                            (ltu/get-op "activate"))
+      (let [activate-op         (-> session-jane
+                                    (request uri-nuvlabox)
+                                    (ltu/body->edn)
+                                    (ltu/is-status 200)
+                                    (ltu/is-operation-absent "delete")
+                                    (ltu/is-operation-absent "edit")
+                                    (ltu/is-operation-present "activate")
+                                    (ltu/get-op "activate"))
 
-            activate-url (str p/service-context activate-op)
+            activate-url        (str p/service-context activate-op)
 
-            ;; anonymous should be able to activate the NuvlaBox
-            credential-id (-> session-anon
-                              (request activate-url
-                                       :request-method :post)
-                              (ltu/body->edn)
-                              (ltu/is-status 200)
-                              (ltu/is-key-value (comp not str/blank?) :secret-key true)
-                              (get-in [:response :body :api-key]))
+            ;; anonymous should be able to activate the NuvlaBox and get back an api key and secret to access Nuvla
+            credential-id       (-> session-anon
+                                    (request activate-url
+                                             :request-method :post)
+                                    (ltu/body->edn)
+                                    (ltu/is-status 200)
+                                    (ltu/is-key-value (comp not str/blank?) :secret-key true)
+                                    (get-in [:response :body :api-key]))
 
-            credential-url (str p/service-context credential-id)
+            credential-url      (str p/service-context credential-id)
 
-            nuvlabox-claims (-> session-admin
-                                (request credential-url)
-                                (ltu/body->edn)
-                                (ltu/is-status 200)
-                                :response
-                                :body
-                                :claims)]
+            credential-nuvlabox (-> session-admin
+                                    (request credential-url)
+                                    (ltu/body->edn)
+                                    (ltu/is-status 200)
+                                    :response
+                                    :body)]
 
-        (is (:identity nuvlabox-claims) "user/test")
-        (is (= (-> nuvlabox-claims :roles set) #{"group/nuvla-anon"
-                                                 id-nuvlabox
-                                                 "group/nuvla-user"}) ))
+        ;; check generated credentials acl and claims. Owners of the box should get edit-acl on it
+        ;; check that the nuvlabox-id is the identity in the claims
+        (is (= (-> credential-nuvlabox :claims :identity) id-nuvlabox))
+        (is (= (-> credential-nuvlabox :claims :roles set) #{"group/nuvla-user"
+                                                             "group/nuvla-anon"}))
+        (is (= (-> credential-nuvlabox :acl :owners set) #{"group/nuvla-admin"}))
+
+        (is (= (-> credential-nuvlabox :acl :edit-acl set) #{id-nuvlabox
+                                                             "user/alpha"}))
+
+        (is (= (-> credential-nuvlabox :acl :view-acl set) #{id-nuvlabox
+                                                             "user/alpha"
+                                                             "user/jane"}))
+        )
 
       ;; user should be able to see the resource
       (-> session-jane


### PR DESCRIPTION
This pull request create an api secret for the NuvlaBox. **This pull request should be merged into nuvlabox-record branch** if @loomis accept this implementation.

*Implementation details:*

The generated credential claims are as following:
the identity is the id of the NuvlaBox and roles are group/nuvla-user and group/nuvla-anon.

The credential has the more or less the same acl as the nuvlabox-record. But the owner of the credential is fixed to nuvla-admin and owners of acl of the NuvlaBox are merged into edit-acl of the credential. This is not really needed and can be the same as the NuvlaBox record. @loomis you can decide.

