### PR TITLE
refactor resource id utilities

### DIFF
--- a/code/src/sixsq/nuvla/server/resources/common/crud.clj
+++ b/code/src/sixsq/nuvla/server/resources/common/crud.clj
@@ -18,7 +18,7 @@
 
 (defn resource-id-dispatch
   [resource-id & _]
-  (first (u/split-resource-id resource-id)))
+  (first (u/parse-id resource-id)))
 
 
 (defn resource-name-and-action-dispatch

--- a/code/src/sixsq/nuvla/server/resources/common/utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/common/utils.clj
@@ -61,22 +61,39 @@
   (str resource-name "/" (random-uuid)))
 
 
-(defn split-resource-id
-  "Provide a tuple of [type docid] for a resource ID. For IDs that don't have
-   an identifier part (e.g. the cloud-entry-point), the document ID will be nil."
+(defn parse-id
+  "Parses a resource id to provide a tuple of [resource-type uuid] for an id.
+   For ids that don't have an identifier part (e.g. the cloud-entry-point), the
+   document id will be nil. For any invalid argument, nil is returned."
   [id]
-  (let [[type docid] (str/split id #"/")]
-    [type docid]))
+  (when (string? id)
+    (let [[resource uuid] (str/split id #"/")]
+      [resource uuid])))
 
 
-(defn resource-name
+(defn id->request-params
+  "Creates the request path params map {:resource-name \"name\", :uuid
+   \"uuid\"} for the given id. If the id isn't valid, then nil is returned."
+  [id]
+  (when-let [[resource-type uuid] (parse-id id)]
+    (cond-> {:resource-name resource-type}                  ;; resource-name is historical
+            uuid (assoc :uuid uuid))))
+
+
+(defn id->resource-type
+  "Parses a resource id to provide a tuple of [resource-type uuid] for an id.
+   For ids that don't have an identifier part (e.g. the cloud-entry-point), the
+   document id will be nil. For any invalid argument, nil is returned."
   [resource-id]
-  (first (split-resource-id resource-id)))
+  (first (parse-id resource-id)))
 
 
-(defn document-id
+(defn id->uuid
+  "Parses a resource id to provide a tuple of [resource-type uuid] for an id.
+   For ids that don't have an identifier part (e.g. the cloud-entry-point), the
+   document id will be nil. For any invalid argument, nil is returned."
   [resource-id]
-  (second (split-resource-id resource-id)))
+  (second (parse-id resource-id)))
 
 
 (defn md5 [^String s]

--- a/code/src/sixsq/nuvla/server/resources/module.clj
+++ b/code/src/sixsq/nuvla/server/resources/module.clj
@@ -212,7 +212,7 @@ component, or application.
 
 (defn delete-content
   [content-id type]
-  (let [delete-request {:params      {:uuid          (-> content-id u/split-resource-id second)
+  (let [delete-request {:params      {:uuid          (-> content-id u/parse-id second)
                                       :resource-name (type->resource-name type)}
                         :body        {:id content-id}
                         :nuvla/authn auth/internal-identity}]

--- a/code/src/sixsq/nuvla/server/resources/session_api_key.clj
+++ b/code/src/sixsq/nuvla/server/resources/session_api_key.clj
@@ -83,7 +83,7 @@
             claims (:claims cookie-info)
             session (cond-> (assoc session :expiry expires)
                             claims (assoc :roles claims))]
-        (log/debug "api-key cookie token claims for " (u/document-id href) ":" cookie-info)
+        (log/debug "api-key cookie token claims for " (u/id->uuid href) ":" cookie-info)
         (let [cookies {authn-info/authn-cookie cookie}]
           [{:cookies cookies} session]))
       (throw (r/ex-unauthorized key)))))

--- a/code/src/sixsq/nuvla/server/resources/session_password.clj
+++ b/code/src/sixsq/nuvla/server/resources/session_password.clj
@@ -59,7 +59,7 @@
           session (cond-> (assoc session :expiry expires)
                           claims (assoc :roles claims))
           cookies {authn-info/authn-cookie cookie}]
-      (log/debug "password cookie token claims for" (u/document-id href) ":" cookie-info)
+      (log/debug "password cookie token claims for" (u/id->uuid href) ":" cookie-info)
       [{:cookies cookies} session])
     (throw (r/ex-unauthorized username))))
 

--- a/code/test/sixsq/nuvla/server/resources/common/utils_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/common/utils_test.clj
@@ -4,6 +4,7 @@
     [sixsq.nuvla.server.resources.common.utils :as t]
     [sixsq.nuvla.server.util.time :as time]))
 
+
 (deftest check-expired?-and-not-expired?
   (let [past-time (time/to-str (time/ago 10 :minutes))
         future-time (time/to-str (time/from-now 10 :minutes))]
@@ -14,6 +15,7 @@
     (is (false? (t/not-expired? past-time)))
     (is (true? (t/not-expired? future-time)))))
 
+
 (deftest check-select-desc-keys
   (let [resource {:name        "name"
                   :description "description"
@@ -21,3 +23,35 @@
     (is (= resource (t/select-desc-keys resource)))
     (is (= resource (t/select-desc-keys (assoc resource :other "ignored"))))
     (is (= (dissoc resource :name) (t/select-desc-keys (dissoc resource :name))))))
+
+
+(deftest check-id-utils
+  (are [expected id] (= expected (t/parse-id id))
+                     nil nil
+                     nil 47
+                     ["" nil] ""
+                     ["cloud-entry-point" nil] "cloud-entry-point"
+                     ["resource" "uuid"] "resource/uuid"
+                     ["resource" "uuid"] "resource/uuid/ignored")
+
+  (are [expected id] (= expected (t/id->resource-type id))
+                     nil nil
+                     nil 47
+                     "" ""
+                     "cloud-entry-point" "cloud-entry-point"
+                     "resource" "resource/uuid"
+                     "resource" "resource/uuid/ignored")
+
+  (are [expected id] (= expected (t/id->uuid id))
+                     nil nil
+                     nil 47
+                     nil ""
+                     nil "cloud-entry-point"
+                     "uuid" "resource/uuid"
+                     "uuid" "resource/uuid/ignored")
+
+  (are [expected id] (= expected (t/id->request-params id))
+                     nil nil
+                     nil 47
+                     {:resource-name "resource", :uuid "uuid"} "resource/uuid"
+                     {:resource-name "cloud-entry-point"} "cloud-entry-point"))

--- a/code/test/sixsq/nuvla/server/resources/resource_metadata_lifecycle_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/resource_metadata_lifecycle_test.clj
@@ -66,7 +66,7 @@
                                             :response
                                             :body)]
 
-          (is (= (cu/document-id id) identifier)))))))
+          (is (= (cu/id->uuid id) identifier)))))))
 
 
 (deftest bad-methods

--- a/code/test/sixsq/nuvla/server/util/metadata_test_utils.clj
+++ b/code/test/sixsq/nuvla/server/util/metadata_test_utils.clj
@@ -48,7 +48,7 @@
                     (ltu/entries))
 
         type-uris (set (map :type-uri md-docs))
-        ids (set (map u/document-id (map :id md-docs)))]
+        ids (set (map u/id->uuid (map :id md-docs)))]
 
     (is (set? type-uris))
     (is (set? ids))


### PR DESCRIPTION
Refactor the resource id utilities to use names that are clearer. Make the utilities more robust against invalid arguments (notably nil). Add unit tests of these and another utility to generate the request params. 