### PR TITLE
allow owner to delete nuvlabox; update resource name values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+  - Allow the owner of a nuvlabox resource to delete it when 
+    in the DECOMMISSIONED state.
   - NuvlaBox commission action will not create duplicate services 
     and credentials if it is called multiple times.
   - Remove associated deployment-parameters when a deployment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+  - Change name attributes for NuvlaBox resources to contain
+    abbreviated nuvlabox id.
   - Allow the owner of a nuvlabox resource to delete it when 
     in the DECOMMISSIONED state.
   - NuvlaBox commission action will not create duplicate services 

--- a/code/src/sixsq/nuvla/server/resources/nuvlabox.clj
+++ b/code/src/sixsq/nuvla/server/resources/nuvlabox.clj
@@ -222,15 +222,16 @@
 ;;
 
 (defn restrict-acl
-  "Updates the given acl by giving the view-acl and manage rights to all
-   owners, removing all edit-* rights, and setting the owners to only
+  "Updates the given acl by giving the view-acl, manage, and delete rights to
+   all owners, removing all edit-* rights, and setting the owners to only
    [\"group/nuvla-admin\"]."
   [{:keys [owners] :as acl}]
   (-> acl
       (dissoc :edit-meta :edit-data :edit-acl)
       (assoc :owners ["group/nuvla-admin"])
       (update-in [:view-acl] concat owners)
-      (update-in [:manage] concat owners)))
+      (update-in [:manage] concat owners)
+      (update-in [:delete] concat owners)))
 
 
 (defmulti decommission-sync

--- a/code/src/sixsq/nuvla/server/resources/nuvlabox/utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/nuvlabox/utils.clj
@@ -12,7 +12,18 @@
     [sixsq.nuvla.server.resources.infrastructure-service-group :as service-group]
     [sixsq.nuvla.server.resources.infrastructure-service-group :as isg]
     [sixsq.nuvla.server.resources.nuvlabox-status :as nb-status]
-    [sixsq.nuvla.server.util.response :as r]))
+    [sixsq.nuvla.server.util.response :as r]
+    [sixsq.nuvla.server.resources.common.utils :as u]))
+
+
+(defn short-nb-id
+  [nuvlabox-id]
+  (when-let [short-id (some-> nuvlabox-id
+                              u/id->uuid
+                              second
+                              (str/split #"-")
+                              first)]
+    (str "NB " short-id)))
 
 
 (defn create-infrastructure-service-group
@@ -21,8 +32,8 @@
   [{:keys [id owner] :as nuvlabox}]
   (let [isg-acl  {:owners   ["group/nuvla-admin"]
                   :view-acl [owner]}
-        skeleton {:name        (str "service group for " id)
-                  :description (str "services available on the NuvlaBox " id)
+        skeleton {:name        (str (short-nb-id id) " service group")
+                  :description (str "services available on " id)
                   :parent      id
                   :acl         isg-acl}
         {:keys [status body] :as resp} (service-group/create-infrastructure-service-group skeleton)]
@@ -53,7 +64,7 @@
                    :view-meta [owner]
                    :delete    [owner]}
 
-        cred-tmpl {:name        (str "Generated API Key for " (or name id))
+        cred-tmpl {:name        (str (short-nb-id id) " API Key")
                    :description (str/join " " ["Generated API Key for" name (str "(" id ")")])
                    :parent      id
                    :template    {:href    (str "credential-template/" cred-tmpl-api/method)
@@ -103,8 +114,8 @@
   (if endpoint
     (let [acl     {:owners [owner]}
           request {:params      {:resource-name infra-service/resource-type}
-                   :body        {:name        "Minio (S3)"
-                                 :description (str "Minio (S3) for " nuvlabox-id)
+                   :body        {:name        (str "Minio on " (short-nb-id nuvlabox-id))
+                                 :description (str "Minio (S3) on " nuvlabox-id)
                                  :parent      isg-id
                                  :acl         acl
                                  :template    {:href     "infrastructure-service-template/generic"
@@ -148,8 +159,8 @@
   (if endpoint
     (let [acl     {:owners [owner]}
           request {:params      {:resource-name infra-service/resource-type}
-                   :body        {:name        "Docker Swarm Cluster"
-                                 :description (str "Docker Swarm cluster for " nuvlabox-id)
+                   :body        {:name        (str "Swarm on " (short-nb-id nuvlabox-id))
+                                 :description (str "Docker Swarm cluster on " nuvlabox-id)
                                  :parent      isg-id
                                  :acl         acl
                                  :template    {:href     "infrastructure-service-template/generic"
@@ -175,7 +186,7 @@
     (if (and key cert ca)
       (let [acl     {:owners [owner]}
             request {:params      {:resource-name credential/resource-type}
-                     :body        {:name        "Docker Swarm Cluster Credential"
+                     :body        {:name        (str "Swarm Cred." (short-nb-id nuvlabox-id))
                                    :description (str "Docker Swarm cluster credential for " swarm-id " linked to " nuvlabox-id)
                                    :parent      swarm-id
                                    :acl         acl
@@ -217,7 +228,7 @@
     (if (and scope token)
       (let [acl     {:owners [owner]}
             request {:params      {:resource-name credential/resource-type}
-                     :body        {:name        "Docker Swarm Token"
+                     :body        {:name        (str "Swarm Token " (short-nb-id nuvlabox-id))
                                    :description (str "Docker Swarm token for " swarm-id " linked to " nuvlabox-id)
                                    :parent      swarm-id
                                    :acl         acl
@@ -256,7 +267,7 @@
     (if (and access-key secret-key)
       (let [acl     {:owners [owner]}
             request {:params      {:resource-name credential/resource-type}
-                     :body        {:name        "Minio (S3) Credential"
+                     :body        {:name        (str "Minio Cred. " (short-nb-id nuvlabox-id))
                                    :description (str "Minio (S3) credential for " minio-id " linked to " nuvlabox-id)
                                    :parent      minio-id
                                    :acl         acl

--- a/code/src/sixsq/nuvla/server/resources/nuvlabox/utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/nuvlabox/utils.clj
@@ -20,7 +20,6 @@
   [nuvlabox-id]
   (when-let [short-id (some-> nuvlabox-id
                               u/id->uuid
-                              second
                               (str/split #"-")
                               first)]
     (str "NB " short-id)))

--- a/code/test/sixsq/nuvla/server/resources/nuvlabox/utils_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/nuvlabox/utils_test.clj
@@ -1,3 +1,10 @@
 (ns sixsq.nuvla.server.resources.nuvlabox.utils-test
   (:require
-    [clojure.test :refer :all]))
+    [clojure.test :refer :all]
+    [sixsq.nuvla.server.resources.nuvlabox.utils :as t]))
+
+
+(deftest check-short-nb-id
+
+  (is (nil? (t/short-nb-id nil)))
+  (is (= "NB abc" (t/short-nb-id "nuvlabox/abc-def-ghi-jkl"))))


### PR DESCRIPTION
Allow the owner of a nuvlabox resource to delete it from the DECOMMISSIONED state. (Previously only administrators could do that.) 

Also update the name attributes for all resources related to the NuvlaBox so that they contain abbreviated nuvlabox ids. 
