### PR TITLE
do not allow duplicate swarm credentials for nuvlabox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+  - Duplicate infrastructure-service-swarm credentials for a 
+    NuvlaBox are not allowed. Only the credentials created first
+    are retained.
   - The nuvlabox-status (version 0) resource will now overwrite
     the value of the next-heartbeat field with the current time
     (from the server) plus the refresh-interval. 

--- a/code/src/sixsq/nuvla/server/resources/nuvlabox/utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/nuvlabox/utils.clj
@@ -179,6 +179,20 @@
       nil)))
 
 
+(defn get-swarm-cred
+  "Searches for an existing swarm credential tied to the given service.
+   If found, the identifier is returned."
+  [swarm-id]
+  (let [filter (format "subtype='infrastructure-service-swarm' and parent='%s'" swarm-id)
+        body   {:cimi-params {:filter (parser/parse-cimi-filter filter)
+                              :select ["id"]}
+                :nuvla/authn auth/internal-identity}]
+    (-> (db/query credential/resource-type body)
+        second
+        first
+        :id)))
+
+
 (defn create-swarm-cred
   [nuvlabox-id owner swarm-id key cert ca]
   (when swarm-id

--- a/code/src/sixsq/nuvla/server/resources/nuvlabox_0.clj
+++ b/code/src/sixsq/nuvla/server/resources/nuvlabox_0.clj
@@ -53,7 +53,9 @@ a NuvlaBox.
                      (nb-utils/create-minio-service id owner isg-id minio-endpoint))]
 
       (when swarm-id
-        (nb-utils/create-swarm-cred id owner swarm-id swarm-client-key swarm-client-cert swarm-client-ca)
+        (or
+          (nb-utils/get-swarm-cred swarm-id)
+          (nb-utils/create-swarm-cred id owner swarm-id swarm-client-key swarm-client-cert swarm-client-ca))
         (or
           (nb-utils/get-swarm-token swarm-id "MANAGER")
           (nb-utils/create-swarm-token id owner swarm-id "MANAGER" swarm-token-manager))


### PR DESCRIPTION
This PR will not allow duplicate infrastructure-service-swarm credentials to be created for a given NuvlaBox. Note that only the **first** credentials are saved; attempts to update the credentials are ignored. 
