### PR TITLE
standardize uuids formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+  - Switch to UUIDs for identifiers for email, user-identifier,
+    and data-object resources rather than MD5 checksums.
   - The schema for the deployment-parameter resource has changed
     the deployment/href to parent. The parent, node-id, and name
     cannot be changed after creation.

--- a/code/src/sixsq/nuvla/server/resources/data_object.clj
+++ b/code/src/sixsq/nuvla/server/resources/data_object.clj
@@ -1,7 +1,5 @@
 (ns sixsq.nuvla.server.resources.data-object
   (:require
-    [buddy.core.codecs :as co]
-    [buddy.core.hash :as ha]
     [clojure.string :as str]
     [clojure.tools.logging :as log]
     [ring.util.response :as ru]
@@ -167,7 +165,7 @@
 
 (defmethod crud/new-identifier resource-type
   [{:keys [object bucket] :as resource} resource-name]
-  (if-let [new-id (co/bytes->hex (ha/md5 (str object bucket)))]
+  (if-let [new-id (u/from-data-uuid (str object bucket))]
     (assoc resource :id (str resource-name "/" new-id))))
 
 ;;

--- a/code/src/sixsq/nuvla/server/resources/email.clj
+++ b/code/src/sixsq/nuvla/server/resources/email.clj
@@ -50,10 +50,10 @@ address. When the callback is triggered, the `validated` flag is set to true.
 ;; "Implementations" of multimethod declared in crud namespace
 ;;
 
-;; resource identifier is the MD5 checksum of the email address
+;; resource identifier a UUID generated from the email address
 (defmethod crud/new-identifier resource-type
   [resource resource-name]
-  (if-let [new-id (some-> resource :address u/md5)]
+  (if-let [new-id (some-> resource :address u/from-data-uuid)]
     (assoc resource :id (str resource-name "/" new-id))))
 
 

--- a/code/src/sixsq/nuvla/server/resources/user_identifier.clj
+++ b/code/src/sixsq/nuvla/server/resources/user_identifier.clj
@@ -74,7 +74,7 @@ must delete the old one and create a new one.
 (defmethod crud/new-identifier resource-type
   [{:keys [identifier] :as resource} resource-name]
   (->> identifier
-       u/md5
+       u/from-data-uuid
        (str resource-type "/")
        (assoc resource :id)))
 

--- a/code/test/sixsq/nuvla/server/resources/user_identifier_lifecycle_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/user_identifier_lifecycle_test.clj
@@ -111,7 +111,7 @@
             (ltu/is-status 200)))
 
       ;; check content of the resource
-      (let [expected-id (str user-identifier/resource-type "/" (u/md5 (:identifier valid-entry)))
+      (let [expected-id (str user-identifier/resource-type "/" (-> valid-entry :identifier u/from-data-uuid))
             resource    (-> session-admin
                             (request abs-uri)
                             (ltu/body->edn)


### PR DESCRIPTION
Use standard UUIDs (rather than MD5 checksums) for email, user-identifier, and data-object resources.