### PR TITLE
joda-time is required for aws-java-sdk-s3 to work

### DIFF
--- a/code/project.clj
+++ b/code/project.clj
@@ -1,4 +1,4 @@
-(def parent-version "6.7.4")
+(def parent-version "6.7.3")
 (def nuvla-ring-version "2.0.2")
 
 (defproject sixsq.nuvla.server/api-jar "4.2.14-SNAPSHOT"
@@ -39,7 +39,6 @@
    [clj-stacktrace]
    [clojure.java-time]
    [com.amazonaws/aws-java-sdk-s3]
-   [joda-time/joda-time]
    [duratom :exclusions [org.clojure/clojure]]
    [expound]
    [instaparse]

--- a/code/project.clj
+++ b/code/project.clj
@@ -1,4 +1,4 @@
-(def parent-version "6.7.3")
+(def parent-version "6.7.4")
 (def nuvla-ring-version "2.0.2")
 
 (defproject sixsq.nuvla.server/api-jar "4.2.14-SNAPSHOT"
@@ -39,6 +39,7 @@
    [clj-stacktrace]
    [clojure.java-time]
    [com.amazonaws/aws-java-sdk-s3]
+   [joda-time/joda-time]
    [duratom :exclusions [org.clojure/clojure]]
    [expound]
    [instaparse]

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -64,10 +64,6 @@
           <artifactId>jline</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>joda-time</groupId>
-          <artifactId>joda-time</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
         </exclusion>


### PR DESCRIPTION
Do not exclude joda-time and forward declaration of parent 6.7.4 version.

To be merged after https://github.com/nuvla/parent/pull/3 and parent is released.
