### PR TITLE
temporarily extend scope of deployment credential for gnss groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Changed
 
-  - Nuvlabox - Allow Nuvlabox credential to edit reboot action job
+  - Deployment - Extend scope of deployment credential for gnss groups
+  - Nuvlabox - Allow Nuvlabox credential to edit job resource for reboot action
   - Nuvlabox - On commission allow Nuvlabox to remove resources
 
 ## [5.11.0] - 2021-03-08

--- a/code/test/sixsq/nuvla/server/resources/deployment_lifecycle_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/deployment_lifecycle_test.clj
@@ -410,6 +410,9 @@
                                              (ltu/is-status 200)
                                              (ltu/body)
                                              :acl)]
+
+                      (ltu/refresh-es-indices)
+
                       (-> session-user
                           (request dep-param-url)
                           (ltu/body->edn)

--- a/code/test/sixsq/nuvla/server/resources/deployment_lifecycle_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/deployment_lifecycle_test.clj
@@ -1,6 +1,7 @@
 (ns sixsq.nuvla.server.resources.deployment-lifecycle-test
   (:require
     [clojure.data.json :as json]
+    [clojure.string :as str]
     [clojure.test :refer [deftest is use-fixtures]]
     [peridot.core :refer [content-type header request session]]
     [sixsq.nuvla.server.app.params :as p]
@@ -14,7 +15,7 @@
     [sixsq.nuvla.server.util.metadata-test-utils :as mdtu]))
 
 
-(use-fixtures :once ltu/with-test-server-fixture)
+(use-fixtures :each ltu/with-test-server-fixture)
 
 
 (def base-uri (str p/service-context t/resource-type))
@@ -31,21 +32,23 @@
 
 
 (defn valid-module
-  [subtype content]
-  {:id                        (str module/resource-type "/connector-uuid")
-   :resource-type             module/resource-type
-   :created                   timestamp
-   :updated                   timestamp
-   :parent-path               "a/b"
-   :path                      "a/b/c"
-   :subtype                   subtype
+  ([subtype content]
+   (valid-module subtype content "a/b/c"))
+  ([subtype content path]
+   {:id                        (str module/resource-type "/component-uuid")
+    :resource-type             module/resource-type
+    :created                   timestamp
+    :updated                   timestamp
+    :parent-path               (str/join "/" (butlast (str/split path #"/")))
+    :path                      path
+    :subtype                   subtype
 
-   :logo-url                  "https://example.org/logo"
+    :logo-url                  "https://example.org/logo"
 
-   :data-accept-content-types ["application/json" "application/x-something"]
-   :data-access-protocols     ["http+s3" "posix+nfs"]
+    :data-accept-content-types ["application/json" "application/x-something"]
+    :data-access-protocols     ["http+s3" "posix+nfs"]
 
-   :content                   content})
+    :content                   content}))
 
 
 (def valid-component {:author                  "someone"
@@ -598,3 +601,84 @@
                             [base-uri :delete]
                             [resource-uri :options]
                             [resource-uri :post]])))
+
+
+;; FIXME: Remove this test after sixsq.nuvla.server.resources.deployment/gnss-expiry-date.
+;;        The test will fail after this date.
+(deftest gnss-extended-api-key
+  (binding [config-nuvla/*stripe-api-key* nil]
+
+    (doseq [g t/gnss-groups]
+      (is (t/gnss-group? {:nuvla/authn {:active-claim g}} t/gnss-expiry-date)))
+    (doseq [g t/gnss-groups]
+      (is (not (t/gnss-group? {:nuvla/authn {:active-claim g}} "1970-01-01T00:00:00.000Z"))))
+    (is (not (t/gnss-group? {:nuvla/authn {:active-claim "group/hello"}} t/gnss-expiry-date)))
+    (is (not (t/gnss-group? {:nuvla/authn {:active-claim "group/hello"}} "1970-01-01T00:00:00.000Z")))
+
+    (doseq [gg t/gnss-groups]
+      (let [session-anon (-> (ltu/ring-app)
+                             session
+                             (content-type "application/json"))
+            session-admin (header session-anon authn-info-header
+                                  "group/nuvla-admin group/nuvla-user group/nuvla-anon")
+            session-user (header session-anon authn-info-header
+                                 (format "%s group/nuvla-user group/nuvla-anon" gg))
+
+            ;; setup a module that can be referenced from the deployment
+            module-id (-> session-user
+                          (request module-base-uri
+                                   :request-method :post
+                                   :body (json/write-str
+                                           (valid-module "component" valid-component (format "a/b/%s" gg))))
+                          (ltu/body->edn)
+                          (ltu/is-status 201)
+                          (ltu/location))
+
+            valid-deployment {:module {:href module-id}}]
+
+        (let [deployment-id (-> session-user
+                                (request base-uri
+                                         :request-method :post
+                                         :body (json/write-str valid-deployment))
+                                (ltu/body->edn)
+                                (ltu/is-status 201)
+                                (ltu/location))
+              deployment-url (str p/service-context deployment-id)
+              deployment-response (-> session-user
+                                      (request deployment-url)
+                                      (ltu/body->edn)
+                                      (ltu/is-status 200)
+                                      (ltu/is-key-value :state "CREATED")
+                                      (ltu/is-key-value :owner gg))
+              start-url (ltu/get-op-url deployment-response "start")
+              job-url (-> session-user
+                          (request start-url
+                                   :request-method :post)
+                          (ltu/body->edn)
+                          (ltu/is-status 202)
+                          (ltu/location-url))
+              _ (-> session-user
+                    (request job-url)
+                    (ltu/body->edn)
+                    (ltu/is-status 200)
+                    (ltu/is-key-value :state "QUEUED")
+                    (ltu/is-key-value :action "start_deployment"))
+
+              deployment (-> session-user
+                             (request deployment-url)
+                             (ltu/body->edn)
+                             (ltu/is-status 200)
+                             (ltu/is-key-value some? :api-credentials true)
+                             (ltu/body))
+              credential-id (-> deployment :api-credentials :api-key)
+              credential-url (str p/service-context credential-id)
+              credential (-> session-admin
+                             (request credential-url)
+                             (ltu/body->edn)
+                             (ltu/is-status 200)
+                             (ltu/body))]
+
+          (is (= deployment-id (:parent credential)))
+
+          ;; verify that the credential has the correct identity
+          (is (= gg (-> credential :claims :identity))))))))


### PR DESCRIPTION
Adding @mebster into the loop to confirm the need for the change.

The change will work for `group/gnss-admin` and `group/gnss-user` groups and until `2021-08-01T00:00:00.000Z`.