### PR TITLE
Fix deployment_state

### DIFF
--- a/code/src/sixsq/nuvla/server/resources/deployment.clj
+++ b/code/src/sixsq/nuvla/server/resources/deployment.clj
@@ -455,6 +455,14 @@ a container orchestration engine.
   [resource]
   (utils/get-context resource false))
 
+(defmethod job-interface/get-context ["deployment" "deployment_state_10"]
+  [resource]
+  (utils/get-context resource false))
+
+(defmethod job-interface/get-context ["deployment" "deployment_state_60"]
+  [resource]
+  (utils/get-context resource false))
+
 
 (def bulk-action-impl (std-crud/bulk-action-fn resource-type collection-acl collection-type))
 


### PR DESCRIPTION
Allow back `get-context` operation on `deployment_state_10` and `deployment_state_60` jobs.