### PR TITLE
Nuvlabox - status-notes for cluster and status spec accept empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- Nuvlabox - status-notes for cluster and status spec accept empty strings
 - Deployment log - Resource removed and replace by resource-log
 - NuvlaBox Status - new optional attribute `components` for v2, to list all
   NuvlaBox components in the edge device

--- a/code/src/sixsq/nuvla/server/resources/spec/nuvlabox_cluster_2.cljc
+++ b/code/src/sixsq/nuvla/server/resources/spec/nuvlabox_cluster_2.cljc
@@ -53,7 +53,7 @@
            :json-schema/order 16)))
 
 (s/def ::status-notes
-  (-> (st/spec (s/coll-of ::core/nonblank-string :kind vector?))
+  (-> (st/spec (s/coll-of string? :kind vector?))
     (assoc :name "status-notes"
       :json-schema/description "List of notes related with the status of the cluster"
 

--- a/code/src/sixsq/nuvla/server/resources/spec/nuvlabox_status_2.cljc
+++ b/code/src/sixsq/nuvla/server/resources/spec/nuvlabox_status_2.cljc
@@ -44,7 +44,7 @@
            :json-schema/order 80)))
 
 (s/def ::status-notes
-  (-> (st/spec (s/coll-of ::core/nonblank-string :kind vector?))
+  (-> (st/spec (s/coll-of string? :kind vector?))
     (assoc :name "status-notes"
            :json-schema/description "Previously called 'comment', now turned into a list of notes related with the status"
 

--- a/code/test/sixsq/nuvla/server/resources/spec/nuvlabox_cluster_2_test.cljc
+++ b/code/test/sixsq/nuvla/server/resources/spec/nuvlabox_cluster_2_test.cljc
@@ -29,7 +29,7 @@
               :nuvlabox-workers         ["nuvlabox/123-456-abc-def-worker"]
               :nuvlabox-managers        ["nuvlabox/123-456-abc-def-manager"]
               :orchestrator  "swarm"
-              :status-notes  ["message 1" "comment A"]})
+              :status-notes  ["message 1" "comment A" ""]})
 
 
 (deftest check-nuvlabox-cluster

--- a/code/test/sixsq/nuvla/server/resources/spec/nuvlabox_status_2_test.cljc
+++ b/code/test/sixsq/nuvla/server/resources/spec/nuvlabox_status_2_test.cljc
@@ -102,7 +102,7 @@
             :online                      true
             :host-user-home           "/home/user"
             :cluster-node-role        "manager"
-            :status-notes             ["Lost quorum", "Swap disabled"]
+            :status-notes             ["Lost quorum", "Swap disabled", ""]
             :cluster-nodes            ["syz", "xyz", "1dsdr3"]
             :cluster-managers         ["syz"]
             :cluster-join-address     "194.182.171.166:2377"


### PR DESCRIPTION
Fixes #653 