### PR TITLE
fix extraction of active claim and other claims from request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Logging - fix logging of claims
+
 ## [6.0.7] - 2022-12-06
 
 ### Changed

--- a/code/src/sixsq/nuvla/server/middleware/logger.clj
+++ b/code/src/sixsq/nuvla/server/middleware/logger.clj
@@ -1,7 +1,8 @@
 (ns sixsq.nuvla.server.middleware.logger
   (:require
     [clojure.string :as str]
-    [clojure.tools.logging :as log]))
+    [clojure.tools.logging :as log]
+    [sixsq.nuvla.server.middleware.authn-info :as auth-info]))
 
 
 (defn- display-querystring
@@ -13,8 +14,9 @@
 
 
 (defn- display-authn-info
-  [{:keys [nuvla/authn] :as _request}]
-  (let [{:keys [active-claim claims]} authn]
+  [request]
+  (let [{:keys [active-claim claims]} (or (auth-info/extract-header-authn-info request)
+                                          (auth-info/extract-cookie-authn-info request))]
     (str "[" active-claim " - " (str/join "," (sort claims)) "]")))
 
 


### PR DESCRIPTION
Example on a test server:
```
2022-12-13 22:31:01,909 DEBUG - GET /api/nuvlabox/ac3978ad-ed65-4ee5-9925-707133c88d50 [nuvlabox/ac3978ad-ed65-4ee5-9925-707133c88d50 - group/nuvla-anon,group/nuvla-nuvlabox,group/nuvla-user,nuvlabox/ac3978ad-ed65-4ee5-9925-707133c88d50,session/308dc9e4-2ca7-43ee-8f55-fc0e0b9ee5a8] ?
2022-12-13 22:31:01,910 DEBUG - GET /api/nuvlabox-status/a6ba7f3b-3dfe-4e1a-ae79-30278c95e4be [nuvlabox/ac3978ad-ed65-4ee5-9925-707133c88d50 - group/nuvla-anon,group/nuvla-nuvlabox,group/nuvla-user,nuvlabox/ac3978ad-ed65-4ee5-9925-707133c88d50,session/308dc9e4-2ca7-43ee-8f55-fc0e0b9ee5a8] ?
2022-12-13 22:31:01,928 DEBUG - PUT /api/nuvlabox-status/a6ba7f3b-3dfe-4e1a-ae79-30278c95e4be [nuvlabox/ac3978ad-ed65-4ee5-9925-707133c88d50 - group/nuvla-anon,group/nuvla-nuvlabox,group/nuvla-user,nuvlabox/ac3978ad-ed65-4ee5-9925-707133c88d50,session/308dc9e4-2ca7-43ee-8f55-fc0e0b9ee5a8] ?select=nuvlabox-api-endpoint&select=kubelet-version&select=temperatures&select=vulnerabilities&select=gpio-pins
```

Closes #736 