### PR TITLE
Use old function to calculate "next-heartbeat" when no cap NUVLA_HEARTBEAT

### DIFF
--- a/code/src/sixsq/nuvla/server/resources/nuvlabox.clj
+++ b/code/src/sixsq/nuvla/server/resources/nuvlabox.clj
@@ -210,7 +210,7 @@ particular NuvlaBox release.
      :as   body} :body :as request}]
   (let [is-admin?    (-> request
                          utils/throw-when-payment-required
-                         utils/throw-refresh-interval-should-be-bigger
+                         (utils/throw-refresh-interval-should-be-bigger nil)
                          utils/throw-heartbeat-interval-should-be-bigger
                          utils/throw-vpn-server-id-should-be-vpn
                          a/is-admin-request?)
@@ -324,7 +324,7 @@ particular NuvlaBox release.
                     crud/retrieve-by-id-as-admin
                     (a/throw-cannot-edit request))
         resp    (-> request
-                    utils/throw-refresh-interval-should-be-bigger
+                    (utils/throw-refresh-interval-should-be-bigger current)
                     utils/throw-heartbeat-interval-should-be-bigger
                     utils/throw-vpn-server-id-should-be-vpn
                     (restrict-request-body current)

--- a/code/src/sixsq/nuvla/server/resources/nuvlabox/utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/nuvlabox/utils.clj
@@ -337,8 +337,10 @@
                400)))))
 
 (defn throw-refresh-interval-should-be-bigger
-  [request]
-  (throw-value-should-be-bigger request :refresh-interval 30))
+  [request nuvlabox]
+  (if (and nuvlabox (not (has-heartbeat-support? nuvlabox)))
+    (throw-value-should-be-bigger request :refresh-interval 30)
+    (throw-value-should-be-bigger request :refresh-interval 60)))
 
 (defn throw-heartbeat-interval-should-be-bigger
   [request]

--- a/code/src/sixsq/nuvla/server/resources/nuvlabox/utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/nuvlabox/utils.clj
@@ -338,7 +338,7 @@
 
 (defn throw-refresh-interval-should-be-bigger
   [request]
-  (throw-value-should-be-bigger request :refresh-interval 60))
+  (throw-value-should-be-bigger request :refresh-interval 30))
 
 (defn throw-heartbeat-interval-should-be-bigger
   [request]
@@ -360,23 +360,22 @@
           time/to-str))
 
 (defn status-online-attributes
-  [{:keys [heartbeat-interval online]
-    :or   {heartbeat-interval default-heartbeat-interval}
-    :as   _nuvlabox} online-new]
+  [online online-new time-interval]
   (cond-> {:online  online-new
            :updated (time/now-str)}
           online-new (assoc :last-heartbeat (time/now-str)
                             :next-heartbeat (compute-next-report
-                                              heartbeat-interval
+                                              time-interval
                                               #(-> % (* 2) (+ 10))))
           (some? online)
           (assoc :online-prev online)))
 
 (defn set-online!
-  [{:keys [id nuvlabox-status heartbeat-interval]
+  [{:keys [id nuvlabox-status heartbeat-interval online]
     :or   {heartbeat-interval default-heartbeat-interval}
     :as   nuvlabox} online-new]
-  (let [nb-status (status-online-attributes nuvlabox online-new)]
+  (let [nb-status (status-online-attributes
+                    online online-new heartbeat-interval)]
     (r/throw-response-not-200
       (db/scripted-edit id {:doc {:online             online-new
                                   :heartbeat-interval heartbeat-interval}}))
@@ -413,8 +412,8 @@
   (str/starts-with? (auth/current-active-claim request) "nuvlabox/"))
 
 (defn legacy-heartbeat
-  [nuvlabox-status request nuvlabox]
+  [nuvlabox-status request {:keys [online refresh-interval] :as nuvlabox}]
   (if (and (nuvlabox-request? request)
            (not (has-heartbeat-support? nuvlabox)))
-    (merge nuvlabox-status (status-online-attributes nuvlabox true))
+    (merge nuvlabox-status (status-online-attributes online true refresh-interval))
     nuvlabox-status))


### PR DESCRIPTION
Nuvlabox - Refresh interval should not be less than 30s