### PR TITLE
Deployment groups - Add recompute-fleet action, to recompute the edges based on the fleet filter

### DIFF
--- a/code/src/sixsq/nuvla/server/resources/deployment_set/utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/deployment_set/utils.clj
@@ -6,6 +6,7 @@
             [sixsq.nuvla.server.resources.common.state-machine :as sm]
             [sixsq.nuvla.server.resources.common.utils :as u]
             [sixsq.nuvla.server.resources.module.utils :as module-utils]
+            [sixsq.nuvla.server.resources.nuvlabox :as nuvlabox]
             [tilakone.core :as tk]))
 
 (def action-start "start")
@@ -309,3 +310,12 @@
   (if (every? (comp #(= "STOPPED" %) :state) (current-deployments deployment-set-id))
     action-ok
     action-nok))
+
+(defn query-nuvlaboxes
+  [cimi-filter request]
+  (let [{:keys [body]} (crud/query {:params      {:resource-name nuvlabox/resource-type}
+                                    :cimi-params {:filter (parser/parse-cimi-filter cimi-filter)
+                                                  :last   10000}
+                                    :nuvla/authn (:nuvla/authn request)})]
+    (:resources body)))
+

--- a/code/src/sixsq/nuvla/server/resources/spec/deployment_set.cljc
+++ b/code/src/sixsq/nuvla/server/resources/spec/deployment_set.cljc
@@ -3,6 +3,7 @@
     [clojure.spec.alpha :as s]
     [sixsq.nuvla.server.resources.deployment-set.utils :as utils]
     [sixsq.nuvla.server.resources.spec.common :as common]
+    [sixsq.nuvla.server.resources.spec.core :as core]
     [sixsq.nuvla.server.resources.spec.credential-template :as cred-spec]
     [sixsq.nuvla.server.resources.spec.deployment-set-operational-status :as os]
     [sixsq.nuvla.server.resources.spec.module-applications-sets :as module-sets]
@@ -32,6 +33,14 @@
          :json-schema/display-name "fleet"
          :json-schema/description "List of targeted edge ids."))
 
+(s/def ::fleet-filter
+  (-> (st/spec ::core/nonblank-string)
+      (assoc :name "fleet-filter"
+             :json-schema/type "string"
+
+             :json-schema/display-name "fleet filter"
+             :json-schema/description "filter for fleet associated with this deployment set")))
+
 (s/def ::start
   (assoc (st/spec boolean?)
     :name "start"
@@ -42,7 +51,8 @@
 (s/def ::set-overwrites
   (assoc (st/spec (su/only-keys :opt-un [::module-sets/applications
                                          ::targets
-                                         ::fleet]))
+                                         ::fleet
+                                         ::fleet-filter]))
     :name "set-overwrites"
     :json-schema/type "map"))
 


### PR DESCRIPTION
Closes SixSq/tasklist#2577
