### PR TITLE
Middleware - Parser cimi-params remove support expand non used option

### DIFF
--- a/code/src/sixsq/nuvla/db/es/select.clj
+++ b/code/src/sixsq/nuvla/db/es/select.clj
@@ -4,4 +4,4 @@
   "Adds the list of keys to select from the returned documents."
   [{:keys [select] :as _cimi-params}]
   (when select
-    {:_source (-> select vec (conj "acl"))}))
+    {:_source (-> select (conj "id" "acl" "resource-type" "state") vec)}))

--- a/code/src/sixsq/nuvla/server/middleware/cimi_params.clj
+++ b/code/src/sixsq/nuvla/server/middleware/cimi_params.clj
@@ -21,11 +21,7 @@
                   combined with a logical AND.  This will be nil if
                   the parameter was not specified or was invalid.
     - :select     contains a set of the attributes the client has
-                  selected.  Will be nil if unspecified or if the
-                  user specified the wildcard '*'.
-    - :expand     indicates the reference attributes to expand in the
-                  response: :none if unspecified, :all if the wildcard
-                  was used, or an explicit set of attributes.
+                  selected.  Will be nil if unspecified.
     - :orderby    nil if unspecified or no valid values were provided.
                   Otherwise, provides an ordered vector of attribute,
                   direction pairs.  The direction is either :asc
@@ -51,7 +47,6 @@
     (let [cimi-params {:first       (impl/cimi-first params)
                        :last        (impl/cimi-last params)
                        :filter      (impl/cimi-filter params)
-                       :expand      (impl/cimi-expand params)
                        :select      (impl/cimi-select params)
                        :format      (impl/cimi-format params)
                        :orderby     (impl/cimi-orderby params)

--- a/code/src/sixsq/nuvla/server/middleware/cimi_params/impl.clj
+++ b/code/src/sixsq/nuvla/server/middleware/cimi_params/impl.clj
@@ -32,31 +32,15 @@
            parser/parse-cimi-filter
            utils/throw-illegal-for-invalid-filter))
 
-(defn cimi-expand
-  "Calculates the value for the :expand key in the CIMI parameters map. The
-  value will be :none if the attribute wasn't specified or if no valid values
-  were given. If the wildcard is specified '*', then :all will be given as the
-  value. In all other cases, a set of the specified attributes will be
-  provided."
-  [{:keys [expand] :as _params}]
-  (->> expand
-       utils/as-vector
-       (mapcat utils/comma-split)
-       set
-       utils/reduce-expand-set))
-
 (defn cimi-select
   "Calculates the value for the :select key in the CIMI parameters map. The
-  value will be nil if the select key was not specified or if the wildcard
-  value '*' is given. Otherwise a set of the desired keys (with 'resource-type'
-  added automatically) is returned."
+   value will be nil if the select key was not specified. Otherwise a set of the
+   desired keys is returned."
   [{:keys [select] :as _params}]
   (some->> select
            utils/as-vector
            (mapcat utils/comma-split)
-           (cons "resource-type")
-           set
-           utils/reduce-select-set))
+           set))
 
 (defn cimi-format
   "Calculates the value for the :format key in the CIMI parameters map. The

--- a/code/src/sixsq/nuvla/server/middleware/cimi_params/utils.clj
+++ b/code/src/sixsq/nuvla/server/middleware/cimi_params/utils.clj
@@ -62,15 +62,6 @@
          (remove str/blank?))
     []))
 
-(defn reduce-expand-set
-  "Reduce the given set to :all if the set contains the wildcard '*' or to
-  :none if the set is empty or nil. Otherwise this returns the original set."
-  [key-set]
-  (cond
-    (contains? key-set "*") :all
-    (empty? key-set) :none
-    :else key-set))
-
 (defn reduce-select-set
   "Reduce the given set to nil if the set contains the wildcard '*'. If the
    wildcard is not present, then the initial key set will be returned (which

--- a/code/test/sixsq/nuvla/db/binding_queries.clj
+++ b/code/test/sixsq/nuvla/db/binding_queries.clj
@@ -141,7 +141,7 @@
           (is (every? :attr1 query-hits))
           (is (every? :sequence query-hits))
           (is (every? :acl query-hits))                     ;; always added to select list
-          (is (every? #(nil? (:id %)) query-hits))
+          (is (every? #(nil? (:admin %)) query-hits))
           (is (every? #(nil? (:attr2 %)) query-hits)))
 
         ;; attribute exists

--- a/code/test/sixsq/nuvla/server/middleware/cimi_params/impl_test.clj
+++ b/code/test/sixsq/nuvla/server/middleware/cimi_params/impl_test.clj
@@ -43,21 +43,11 @@
 (deftest check-params->select
   (are [expect arg] (= expect (t/cimi-select {:select arg}))
                     nil nil
-                    nil "*"
-                    #{"a" "resource-type"} "a"
-                    #{"a" "resource-type"} " a "
-                    #{"a" "resource-type"} "a,a"
-                    #{"a" "resource-type"} [" a,a" "a" "a"]
-                    #{"a" "a2" "resource-type"} " a, a2 "))
-
-(deftest check-params->expand
-  (are [expect arg] (= expect (t/cimi-expand {:expand arg}))
-                    :none nil
-                    :all "*"
                     #{"a"} "a"
-                    #{"a" "b"} "a,b"
-                    #{"a" "b"} " a , b "
-                    #{"a" "b"} ["a" "b"]))
+                    #{"a"} " a "
+                    #{"a"} "a,a"
+                    #{"a"} [" a,a" "a" "a"]
+                    #{"a" "a2"} " a, a2 "))
 
 (deftest check-params->orderby
   (are [expect arg] (= expect (t/cimi-orderby {:orderby arg}))

--- a/code/test/sixsq/nuvla/server/middleware/cimi_params/utils_test.clj
+++ b/code/test/sixsq/nuvla/server/middleware/cimi_params/utils_test.clj
@@ -56,21 +56,6 @@
                     [] nil))
 
 
-(deftest check-reduce-select-set
-  (are [expect arg] (= expect (t/reduce-select-set arg))
-                    #{"a" "b"} (set ["a" "b" "a" "b"])
-                    nil (set ["a" "b" "*"])
-                    nil nil))
-
-
-(deftest check-reduce-expand-set
-  (are [expect arg] (= expect (t/reduce-expand-set arg))
-                    :all #{"*"}
-                    :none #{}
-                    :none nil
-                    #{"a" "b"} #{"a" "b"}))
-
-
 (deftest check-orderby-clause
   (are [expect arg] (= expect (t/orderby-clause arg))
                     nil ":asc"


### PR DESCRIPTION
Middleware - Parser cimi-params remove support for wildcard in select option ES binding - Always retrieve id acl state resource-type usually needed Std-crud - Return only what user is asking for