### PR TITLE
auto event generation framework plus enabled events on module publication

### DIFF
--- a/code/src/sixsq/nuvla/server/app/routes.clj
+++ b/code/src/sixsq/nuvla/server/app/routes.clj
@@ -37,11 +37,11 @@
     (PUT uri request
       (ec/add-to-context :params (:params request))
       (ec/add-to-context :category "edit")
-      (crud/edit request))
+      (crud/edit (assoc-in request [:params :action] crud/action-edit)))
     (DELETE uri request
       (ec/add-to-context :params (:params request))
       (ec/add-to-context :category "delete")
-      (crud/delete request))
+      (crud/delete (assoc-in request [:params :action] crud/action-delete)))
     (ANY uri request
       (throw (r/ex-bad-method request)))))
 
@@ -90,4 +90,3 @@
                                 (route/resources (str p/service-context "static"))]
                                (dyn/resource-routes)
                                final-routes))))
-

--- a/code/src/sixsq/nuvla/server/app/routes.clj
+++ b/code/src/sixsq/nuvla/server/app/routes.clj
@@ -6,18 +6,24 @@
     [sixsq.nuvla.server.app.params :as p]
     [sixsq.nuvla.server.resources.common.crud :as crud]
     [sixsq.nuvla.server.resources.common.dynamic-load :as dyn]
+    [sixsq.nuvla.server.resources.common.event-context :as ec]
     [sixsq.nuvla.server.util.response :as r]))
 
 
 (def collection-routes
   (let-routes [uri (str p/service-context ":resource-name")]
     (POST uri request
+      (ec/add-to-context :params (:params request))
+      (ec/add-to-context :category "add")
       (crud/add request))
     (PUT uri request
+      (ec/add-to-context :params (:params request))
       (crud/query request))
     (GET uri request
+      (ec/add-to-context :params (:params request))
       (crud/query request))
     (DELETE uri request
+      (ec/add-to-context :params (:params request))
       (crud/bulk-delete request))
     (ANY uri request
       (throw (r/ex-bad-method request)))))
@@ -26,11 +32,16 @@
 (def resource-routes
   (let-routes [uri (str p/service-context ":resource-name/:uuid")]
     (GET uri request
+      (ec/add-to-context :params (:params request))
       (crud/retrieve request))
     (PUT uri request
-      (crud/edit (assoc-in request [:params :action] crud/action-edit)))
+      (ec/add-to-context :params (:params request))
+      (ec/add-to-context :category "edit")
+      (crud/edit request))
     (DELETE uri request
-      (crud/delete (assoc-in request [:params :action] crud/action-delete)))
+      (ec/add-to-context :params (:params request))
+      (ec/add-to-context :category "delete")
+      (crud/delete request))
     (ANY uri request
       (throw (r/ex-bad-method request)))))
 
@@ -38,12 +49,15 @@
 (def action-routes
   (let-routes [uri (str p/service-context ":resource-name/:uuid/:action")]
     (ANY uri request
+      (ec/add-to-context :params (:params request))
+      (ec/add-to-context :category "action")
       (crud/do-action request))))
 
 
 (def bulk-action-routes
   (let-routes [uri (str p/service-context ":resource-name/:action")]
     (PATCH uri request
+      (ec/add-to-context :params (:params request))
       (crud/bulk-action request))))
 
 
@@ -76,3 +90,4 @@
                                 (route/resources (str p/service-context "static"))]
                                (dyn/resource-routes)
                                final-routes))))
+

--- a/code/src/sixsq/nuvla/server/app/server.clj
+++ b/code/src/sixsq/nuvla/server/app/server.clj
@@ -16,6 +16,7 @@
     [sixsq.nuvla.server.middleware.cimi-params :refer [wrap-cimi-params]]
     [sixsq.nuvla.server.middleware.default-content-type :refer [default-content-type]]
     [sixsq.nuvla.server.middleware.exception-handler :refer [wrap-exceptions]]
+    [sixsq.nuvla.server.middleware.eventer :refer [wrap-eventer]]
     [sixsq.nuvla.server.middleware.gzip :refer [wrap-gzip-uncompress]]
     [sixsq.nuvla.server.middleware.logger :refer [wrap-logger]]
     [sixsq.nuvla.server.middleware.redirect-cep :refer [redirect-cep]]
@@ -45,9 +46,10 @@
       wrap-nested-params
       wrap-params
       wrap-exceptions
-      wrap-authn-info
       (wrap-json-body {:keywords? true})
       wrap-gzip-uncompress
+      wrap-eventer
+      wrap-authn-info
       (wrap-json-response {:pretty           true
                            :escape-non-ascii true})
       (default-content-type "application/json")

--- a/code/src/sixsq/nuvla/server/middleware/eventer.clj
+++ b/code/src/sixsq/nuvla/server/middleware/eventer.clj
@@ -1,0 +1,17 @@
+(ns sixsq.nuvla.server.middleware.eventer
+  (:require [sixsq.nuvla.server.resources.common.event-config :as config]
+            [sixsq.nuvla.server.resources.common.event-context :as ec]
+            [sixsq.nuvla.server.resources.event.utils :as eu]))
+
+(defn wrap-eventer
+  "Creates an event after handler execution, if eventing is enabled for the resource type."
+  [handler]
+  (fn [request]
+    (ec/with-context
+      (let [response      (handler request)
+            resource-type (-> (ec/get-context) :params :resource-name)]
+        (when (config/events-enabled? resource-type)
+          (let [event (eu/build-event (ec/get-context) request response)]
+            (when (config/log-event? event response)
+              (eu/add-event event))))
+        response))))

--- a/code/src/sixsq/nuvla/server/resources/common/crud.clj
+++ b/code/src/sixsq/nuvla/server/resources/common/crud.clj
@@ -2,6 +2,7 @@
   (:require
     [sixsq.nuvla.auth.acl-resource :as a]
     [sixsq.nuvla.auth.utils :as auth]
+    [sixsq.nuvla.db.filter.parser :as parser]
     [sixsq.nuvla.db.impl :as db]
     [sixsq.nuvla.server.resources.common.utils :as u]
     [sixsq.nuvla.server.util.response :as r]))
@@ -273,3 +274,17 @@
 (defmethod add-acl :default
   [json _request]
   json)
+
+;;
+;; Given resource type, filter and request, return count of the found resources.
+;;
+
+(defn query-count
+  [resource-type filter-str request]
+  (-> {:params      {:resource-name resource-type}
+       :cimi-params {:filter (parser/parse-cimi-filter filter-str)
+                     :last   0}
+       :nuvla/authn (auth/current-authentication request)}
+      query
+      :body
+      :count))

--- a/code/src/sixsq/nuvla/server/resources/common/crud.clj
+++ b/code/src/sixsq/nuvla/server/resources/common/crud.clj
@@ -92,6 +92,16 @@
   [resource-id]
   (retrieve-by-id resource-id {:nuvla/authn auth/internal-identity}))
 
+(defn retrieve-by-id-as-admin1
+  "Same as `retrieve-by-id-as-admin` but if the resource is not found returns nil
+   instead of throwing an exception."
+  [resource-id]
+  (try (retrieve-by-id-as-admin resource-id)
+       (catch Exception ex
+         (when-not (= 404 (:status (ex-data ex)))
+           (throw ex)))))
+
+
 (defn id->user-request
   [id request]
   {:params         (u/id->request-params id)

--- a/code/src/sixsq/nuvla/server/resources/common/event_config.clj
+++ b/code/src/sixsq/nuvla/server/resources/common/event_config.clj
@@ -1,0 +1,82 @@
+(ns sixsq.nuvla.server.resources.common.event-config
+  (:require [sixsq.nuvla.server.resources.common.crud :as crud]
+            [sixsq.nuvla.server.resources.common.utils :as u]))
+
+;;
+;; Dispatch functions
+;;
+
+(defn resource-type-dispatch [resource-type]
+  resource-type)
+
+
+(defn event-name-dispatch [{event-name :name :as _event} & rest]
+  event-name)
+
+
+;;
+;; Enabled/disabled events
+;;
+
+(defmulti events-enabled?
+          "Returns true if events should be logged for the given resource-type, false otherwise."
+          resource-type-dispatch)
+
+
+(defmethod events-enabled? :default
+  [_resource-type]
+  false)
+
+
+;;
+;; Whitelist and blacklist event types per resource type
+;;
+
+(defmulti log-event?
+          "Returns true if the event should be logged, false otherwise."
+          event-name-dispatch)
+
+
+(defmethod log-event? :default
+  [{event-name :name :as _event} {:keys [status] :as _response}]
+  (and (not= 405 status)
+       (some? event-name)))
+
+
+;;
+;; Event human readable description
+;;
+
+(defmulti event-description
+          "Returns a human-readable description of the event"
+          event-name-dispatch)
+
+
+(defmethod event-description :default
+  [{:keys [success authn-info category content] event-name :name :as _event}
+   & [{:keys [resource] :as _context}]]
+  (if success
+    (let [user-name-or-id (or (some-> authn-info :user-id crud/retrieve-by-id-as-admin1 :name)
+                              (:user-id authn-info))
+          resource-id     (-> content :resource :href)
+          resource-type   (u/id->resource-type resource-id)
+          resource        (or resource
+                              (crud/retrieve-by-id-as-admin1 resource-id))
+          resource-name   (:name resource)
+          resource-name-or-id (or resource-name resource-id)]
+      (case category
+        ("add" "edit" "delete" "action")
+        (str (or user-name-or-id "An anonymous user")
+             (case category
+               "add" (str " added " resource-type " " resource-name-or-id)
+               "edit" (str " edited " resource-type " " resource-name-or-id)
+               "delete" (str " deleted " resource-type " " resource-name-or-id)
+               "action" (let [action (some->> event-name (re-matches #".*\.(.*)") second)]
+                          (str " executed action " action " on " resource-type " " resource-name-or-id))
+               nil)
+             ".")
+        ("state" "alarm" "email" "user")
+        event-name                                          ;; FIXME: improve description in this case
+        event-name))
+    (str event-name " attempt failed.")))
+

--- a/code/src/sixsq/nuvla/server/resources/common/event_context.clj
+++ b/code/src/sixsq/nuvla/server/resources/common/event_context.clj
@@ -1,0 +1,40 @@
+(ns sixsq.nuvla.server.resources.common.event-context
+  (:require [sixsq.nuvla.server.util.time :as t]))
+
+
+(def ^:dynamic *context*)
+
+
+(defmacro with-context
+  "Initializes an event context map.
+   Information can be added to the context via `add-to-context`.
+   The context can be retrieved via `get-context`."
+  [& body]
+  `(binding [*context* (atom {:timestamp (t/now-str)})]
+     ~@body))
+
+
+(defn get-context
+  "Returns the current context."
+  []
+  (some-> *context* deref))
+
+
+(defn add-to-context
+  "Adds value `v` to the current context under key `k`."
+  [k v]
+  (when @*context*
+    (swap! *context* assoc k v)))
+
+(defn add-to-visible-to
+  "Adds `v` to visible to"
+  [& claims]
+  (when @*context*
+    (swap! *context* update :visible-to concat claims)))
+
+
+(defn add-linked-identifier
+  "Adds the identifier of a linked entity to the context."
+  [id]
+  (when (and (some? id) @*context*)
+    (swap! *context* update :linked-identifiers conj id)))

--- a/code/src/sixsq/nuvla/server/resources/common/event_context.clj
+++ b/code/src/sixsq/nuvla/server/resources/common/event_context.clj
@@ -2,7 +2,7 @@
   (:require [sixsq.nuvla.server.util.time :as t]))
 
 
-(def ^:dynamic *context*)
+(def ^:dynamic *context* nil)
 
 
 (defmacro with-context
@@ -23,7 +23,7 @@
 (defn add-to-context
   "Adds value `v` to the current context under key `k`."
   [k v]
-  (when @*context*
+  (when (and (not (nil? *context*)) @*context*)
     (swap! *context* assoc k v)))
 
 (defn add-to-visible-to

--- a/code/src/sixsq/nuvla/server/resources/common/event_context.clj
+++ b/code/src/sixsq/nuvla/server/resources/common/event_context.clj
@@ -23,7 +23,7 @@
 (defn add-to-context
   "Adds value `v` to the current context under key `k`."
   [k v]
-  (when (and (not (nil? *context*)) @*context*)
+  (when (get-context)
     (swap! *context* assoc k v)))
 
 (defn add-to-visible-to

--- a/code/src/sixsq/nuvla/server/resources/common/utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/common/utils.clj
@@ -67,6 +67,11 @@
   (str resource-name "/" (random-uuid)))
 
 
+(defn resource-id
+  [resource-type uuid]
+  (str resource-type "/" uuid))
+
+
 (defn parse-id
   "Parses a resource id to provide a tuple of [resource-type uuid] for an id.
    For ids that don't have an identifier part (e.g. the cloud-entry-point), the
@@ -84,6 +89,25 @@
   (when-let [[resource-type uuid] (parse-id id)]
     (cond-> {:resource-name resource-type}                  ;; resource-name is historical
             uuid (assoc :uuid uuid))))
+
+
+(defn request->resource-type
+  "Extracts the resource type from a request map."
+  [request]
+  (get-in request [:params :resource-name]))
+
+
+(defn request->resource-uuid
+  "Extracts the resource uuid from a request map."
+  [request]
+  (get-in request [:params :uuid]))
+
+
+(defn request->resource-id
+  "Extracts the resource id from a request map."
+  [request]
+  (some->> (request->resource-uuid request)
+           (resource-id (request->resource-type request))))
 
 
 (defn id->resource-type
@@ -330,15 +354,21 @@
                                      (->> (select-keys body)))]
     (merge current-without-selected editable-body)))
 
+
 (defn is-state-within?
   [states resource]
   (contains? (set states) (:state resource)))
 
+
 (def is-state-besides? (complement is-state-within?))
+
 
 (defn is-state?
   [state resource]
   (= (:state resource) state))
+
+(def is-not-in-state? (complement is-state?))
+
 
 (defn throw-can-not-do-action
   [{:keys [id] :as resource} pred action]

--- a/code/src/sixsq/nuvla/server/resources/credential/utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/credential/utils.clj
@@ -1,0 +1,15 @@
+(ns sixsq.nuvla.server.resources.credential.utils
+  "General utilities for dealing with credential resources and collection."
+  (:require
+    [sixsq.nuvla.server.resources.common.crud :as crud]
+    [sixsq.nuvla.server.resources.common.utils :as u]
+    [sixsq.nuvla.server.resources.credential :as credential]))
+
+(defn all-registry-creds-exist
+  [creds request]
+  (and (seq creds)
+       (< (crud/query-count credential/resource-type
+                         (str "subtype='infrastructure-service-registry' and "
+                              (u/filter-eq-vals "id" creds))
+                         request)
+          (count creds))))

--- a/code/src/sixsq/nuvla/server/resources/event/utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/event/utils.clj
@@ -4,40 +4,210 @@
     [sixsq.nuvla.auth.utils :as auth]
     [sixsq.nuvla.db.filter.parser :as parser]
     [sixsq.nuvla.server.resources.common.crud :as crud]
+    [sixsq.nuvla.server.resources.common.event-config :as ec]
+    [sixsq.nuvla.server.resources.common.utils :as u]
     [sixsq.nuvla.server.resources.event :as event]
+    [sixsq.nuvla.server.util.time :as t]
     [sixsq.nuvla.server.util.time :as time]))
+
+
+(defn request-event-name
+  "Returns a string of the form <resource-name>.<action>"
+  [{{:keys [resource-name uuid action]} :params :as _context}
+   {:keys [request-method] :as _request}]
+  (if uuid
+    (if action
+      (some->> action (str resource-name "."))
+      (case request-method
+        :put (str resource-name ".edit")
+        :delete (str resource-name ".delete")
+        nil))
+    (case request-method
+      :post (str resource-name ".add")
+      :delete (str resource-name ".bulk.delete")
+      :patch (some->> action (str resource-name ".bulk."))
+      nil)))
+
+
+(defn get-success
+  [{:keys [status] :as _response}]
+  (<= 200 status 399))
+
+
+(defn get-event-name
+  [{:keys [event-name] :as context} request]
+  (or event-name
+      (request-event-name context request)))
+
+
+(defn get-category
+  [{:keys [category] :as _context}]
+  (or category "action"))
+
+
+(defn get-timestamp
+  [{:keys [timestamp] :as _context}]
+  (or timestamp (t/now-str)))
+
+
+(defn retrieve-by-id
+  [id]
+  (try
+    (:body (crud/retrieve {:params         (u/id->request-params id)
+                           :request-method :get
+                           :nuvla/authn    auth/internal-identity}))
+    (catch Exception _ex
+      nil)))
+
+
+(defn get-resource-href
+  [{{:keys [resource-name uuid]} :params :as _context} response]
+  (or (some->> uuid (str resource-name "/"))
+      (-> response :body :resource-id)))
+
+
+(defn transform-acl
+  [acl]
+  (when acl
+    {:owners (vec (concat (:edit-data acl) (:owners acl)))}))
+
+(defn derive-acl-from-resource
+  [context response]
+  (when-let [acl (some-> (get-resource-href context response)
+                         retrieve-by-id
+                         :acl)]
+    (transform-acl acl)))
+
+
+(defn get-acl
+  [{:keys [visible-to acl] :as context} response]
+  (let [visible-to (remove nil? visible-to)]
+    (or (when (seq visible-to)
+          {:owners (-> visible-to (conj "group/nuvla-admin") distinct vec)})
+        (transform-acl acl)
+        (derive-acl-from-resource context response)
+        {:owners ["group/nuvla-admin"]})))
+
+
+(defn get-severity
+  [{:keys [severity] :as _context}]
+  (or severity "medium"))
+
+
+(defn get-resource
+  [context response]
+  {:href (get-resource-href context response)})
+
+
+(defn get-linked-identifiers
+  [{:keys [linked-identifiers] :or {linked-identifiers []} :as _context}]
+  linked-identifiers)
+
+
+(defn get-linked-resource-ids
+  [{{:keys [linked-identifiers]} :content :as _event} resource-type]
+  (->> linked-identifiers
+       (filter (comp #(= resource-type %) u/id->resource-type))))
+
+
+(defn get-linked-resources
+  ([{{:keys [linked-identifiers]} :content :as _event}]
+   (->> linked-identifiers
+        (keep crud/retrieve-by-id-as-admin1)))
+  ([{{:keys [linked-identifiers]} :content :as _event} resource-type]
+   (->> linked-identifiers
+        (filter (comp #(= resource-type %) u/id->resource-type))
+        (keep crud/retrieve-by-id-as-admin1))))
+
+
+(defn set-description
+  [event context]
+  (let [event-description (ec/event-description event context)]
+    (cond-> event
+            event-description (assoc :description event-description))))
+
+
+(defn build-event
+  [context request response]
+  (-> {:resource-type event/resource-type
+       :name          (get-event-name context request)
+       :success       (get-success response)
+       :category      (get-category context)
+       :timestamp     (get-timestamp context)
+       :authn-info    (auth/current-authentication request)
+       :acl           (get-acl context response)
+       :severity      (get-severity context)
+       :content       {:resource           (get-resource context response)
+                       :linked-identifiers (get-linked-identifiers context)}}
+      (set-description context)))
+
+
+(defn add-event
+  [event]
+  (let [create-request {:params      {:resource-name event/resource-type}
+                        :body        event
+                        :nuvla/authn auth/internal-identity}]
+    (crud/add create-request)))
 
 
 (def topic event/resource-type)
 
 
+;; FIXME: duplicated
 (defn create-event
   [resource-href state acl & {:keys [severity category timestamp]
-                                :or   {severity "medium"
-                                       category "action"}}]
-  (let [event-map      {:resource-type event/resource-type
+                              :or   {severity "medium"
+                                     category "action"}}]
+  (let [event-map      {:name          "legacy"
+                        :success       true
+                        :resource-type event/resource-type
                         :content       {:resource {:href resource-href}
                                         :state    state}
                         :severity      severity
                         :category      category
                         :timestamp     (or timestamp (time/now-str))
-                        :acl           acl}
+                        :acl           acl
+                        :authn-info    {}}
         create-request {:params      {:resource-name event/resource-type}
                         :body        event-map
                         :nuvla/authn auth/internal-identity}]
     (crud/add create-request)))
 
 
+(defn query-events
+  ([resource-href opts]
+   (query-events (assoc opts :resource-href resource-href)))
+  ([{:keys [resource-href linked-identifier category state start end orderby last] event-name :name :as opts}]
+   (some-> event/resource-type
+           (crud/query-as-admin
+             {:cimi-params
+              (cond->
+                {:filter (parser/parse-cimi-filter
+                           (str/join " and "
+                                     (cond-> []
+                                             resource-href (conj (str "content/resource/href='" resource-href "'"))
+                                             (and (contains? opts :resource-href) (nil? resource-href)) (conj (str "content/resource/href=null"))
+                                             event-name (conj (str "name='" event-name "'"))
+                                             category (conj (str "category='" category "'"))
+                                             state (conj (str "content/state='" state "'"))
+                                             linked-identifier (conj (str "content/linked-identifiers='" linked-identifier "'"))
+                                             start (conj (str "timestamp>='" start "'"))
+                                             end (conj (str "timestamp<'" end "'")))))}
+                orderby (assoc :orderby orderby)
+                last (assoc :last last))})
+           second)))
+
+;; FIXME: duplicated
 (defn search-event
   [resource-href {:keys [category state start end]}]
   (some-> event/resource-type
           (crud/query-as-admin
             {:cimi-params
-             {:filter (parser/parse-cimi-filter 
-                        (str/join " and " 
+             {:filter (parser/parse-cimi-filter
+                        (str/join " and "
                                   (cond-> [(str "content/resource/href='" resource-href "'")]
-                                    category (conj (str "category='" category "'"))
-                                    state (conj (str "content/state='" state "'"))
-                                    start (conj (str "timestamp>='" start "'"))
-                                    end (conj (str "timestamp<'" end "'")))))}})
+                                          category (conj (str "category='" category "'"))
+                                          state (conj (str "content/state='" state "'"))
+                                          start (conj (str "timestamp>='" start "'"))
+                                          end (conj (str "timestamp<'" end "'")))))}})
           second))

--- a/code/src/sixsq/nuvla/server/resources/event/utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/event/utils.clj
@@ -96,7 +96,10 @@
 
 (defn get-resource
   [context response]
-  {:href (get-resource-href context response)})
+  (if (contains? context :resource)
+    {:href (get-resource-href context response)
+     :content (:resource context)}
+    {:href (get-resource-href context response)}))
 
 
 (defn get-linked-identifiers

--- a/code/src/sixsq/nuvla/server/resources/infrastructure_service/utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/infrastructure_service/utils.clj
@@ -1,0 +1,15 @@
+(ns sixsq.nuvla.server.resources.infrastructure-service.utils
+  "General utilities for dealing with infrastructure-service resources and collection."
+  (:require
+    [sixsq.nuvla.server.resources.common.crud :as crud]
+    [sixsq.nuvla.server.resources.common.utils :as u]
+    [sixsq.nuvla.server.resources.infrastructure-service :as infra-service]))
+
+(defn all-registries-exist
+  [registries request]
+  (and (seq registries)
+       (< (crud/query-count infra-service/resource-type
+                         (str "subtype='registry' and "
+                              (u/filter-eq-vals "id" registries))
+                         request)
+          (count registries))))

--- a/code/src/sixsq/nuvla/server/resources/module.clj
+++ b/code/src/sixsq/nuvla/server/resources/module.clj
@@ -224,6 +224,15 @@ component, or application.
                (dissoc :content)
                (utils/set-price nil request))))
 
+(def event-context-keys [:name
+                         :description
+                         :subtype])
+
+(defn set-event-context
+  [resource]
+  (ectx/add-to-context :resource (select-keys resource event-context-keys))
+  resource)
+
 (defmethod crud/add resource-type
   [request]
   (a/throw-cannot-add collection-acl request)
@@ -236,6 +245,7 @@ component, or application.
       throw-requires-parent
       throw-requires-editable-parent-project
       update-add-request
+      (set-event-context)
       add-impl))
 
 (defmethod crud/retrieve resource-type
@@ -265,7 +275,9 @@ component, or application.
                             :body resource)
                      edit-impl)]
     (if (r/status-200? response)
-      response
+      (do
+        (set-event-context resource)
+        response)
       (throw (r/ex-response (str error-message ": " response) 500)))))
 
 

--- a/code/src/sixsq/nuvla/server/resources/module.clj
+++ b/code/src/sixsq/nuvla/server/resources/module.clj
@@ -226,6 +226,7 @@ component, or application.
 
 (def event-context-keys [:name
                          :description
+                         :path
                          :subtype])
 
 (defn set-event-context
@@ -245,7 +246,7 @@ component, or application.
       throw-requires-parent
       throw-requires-editable-parent-project
       update-add-request
-      (set-event-context)
+      set-event-context
       add-impl))
 
 (defmethod crud/retrieve resource-type

--- a/code/src/sixsq/nuvla/server/resources/spec/common.cljc
+++ b/code/src/sixsq/nuvla/server/resources/spec/common.cljc
@@ -14,14 +14,6 @@
              :json-schema/description "reference to another resource")))
 
 
-(s/def ::resource-link
-  (-> (st/spec (s/keys :req-un [::href]))
-      (assoc :name "resource-link"
-             :json-schema/type "map"
-             :json-schema/display-name "resource link"
-             :json-schema/description "map containing a reference (href) to a resource")))
-
-
 ;;
 ;; core meta
 ;;

--- a/code/src/sixsq/nuvla/server/resources/spec/event.cljc
+++ b/code/src/sixsq/nuvla/server/resources/spec/event.cljc
@@ -66,8 +66,17 @@
              :json-schema/description "reference to associated resource")))
 
 
+(s/def :resource/content
+  (-> (st/spec map?)
+      (assoc :name "content"
+             :json-schema/type "map"
+             :json-schema/description "arbitrary content of the resource"
+             :json-schema/indexed false)))
+
+
 (s/def ::resource
-  (-> (st/spec (su/only-keys :req-un [::href]))
+  (-> (st/spec (su/only-keys :req-un [::href]
+                             :opt-un [:resource/content]))
       (assoc :name "resource"
              :json-schema/type "map"
              :json-schema/description "link to associated resource")))

--- a/code/src/sixsq/nuvla/server/resources/spec/event.cljc
+++ b/code/src/sixsq/nuvla/server/resources/spec/event.cljc
@@ -3,27 +3,41 @@
     [clojure.spec.alpha :as s]
     [sixsq.nuvla.server.resources.spec.common :as common]
     [sixsq.nuvla.server.resources.spec.core :as core]
+    [sixsq.nuvla.server.resources.spec.session :as session]
     [sixsq.nuvla.server.util.spec :as su]
     [spec-tools.core :as st]))
 
+(def -category-values
+  ["add"
+   "edit"
+   "delete"
+   "action"
+   "state"
+   "alarm"
+   "email"
+   "user"])
 
 (s/def ::category
-  (-> (st/spec #{"state" "alarm" "action" "system" "user" "email"})
+  (-> (st/spec (set -category-values))
       (assoc :name "category"
              :json-schema/type "string"
              :json-schema/description "category of event"
-             :json-schema/value-scope {:values ["state" "alarm" "action" "system" "user"
-                                                "email"]}
+             :json-schema/value-scope {:values -category-values}
 
              :json-schema/order 30)))
 
+(def -severity-values
+  ["critical"
+   "high"
+   "medium"
+   "low"])
 
 (s/def ::severity
-  (-> (st/spec #{"critical" "high" "medium" "low"})
+  (-> (st/spec (set -severity-values))
       (assoc :name "severity"
              :json-schema/type "string"
              :json-schema/description "severity level of event"
-             :json-schema/value-scope {:values ["critical", "high", "medium", "low"]}
+             :json-schema/value-scope {:values -severity-values}
 
              :json-schema/order 31)))
 
@@ -46,7 +60,7 @@
 ;; Events may need to reference resources that do not follow the CIMI.
 ;; conventions.  Allow for a more flexible schema to be used here.
 (s/def ::href
-  (-> (st/spec (s/and string? #(re-matches #"^[a-zA-Z0-9]+[a-zA-Z0-9_./-]*$" %)))
+  (-> (st/spec (s/nilable ::core/nonblank-string))
       (assoc :name "href"
              :json-schema/type "string"
              :json-schema/description "reference to associated resource")))
@@ -59,8 +73,23 @@
              :json-schema/description "link to associated resource")))
 
 
+(s/def ::identifier
+  (-> (st/spec string?)
+      (assoc :name "identifier"
+             :json-schema/type "string"
+             :json-schema/description "identifier")))
+
+
+(s/def ::linked-identifiers
+  (-> (st/spec (s/coll-of ::identifier))
+      (assoc :name "linked-identifiers"
+             :json-schema/type "array"
+             :json-schema/description "list of linked identifiers")))
+
 (s/def ::content
-  (-> (st/spec (su/only-keys :req-un [::resource ::state]))
+  (-> (st/spec (su/only-keys :req-un [::resource]
+                             :opt-un [::linked-identifiers
+                                      ::state]))
       (assoc :name "content"
              :json-schema/type "map"
              :json-schema/description "content describing event"
@@ -68,9 +97,43 @@
              :json-schema/order 33)))
 
 
+(s/def ::user-id
+  (-> (st/spec ::core/nonblank-string)
+      (assoc :name "user-id"
+             :json-schema/type "string"
+             :json-schema/description "user id")))
+
+
+(s/def ::claims
+  (-> (st/spec (s/coll-of ::core/nonblank-string))
+      (assoc :name "claims"
+             :json-schema/type "array"
+             :json-schema/description "claims")))
+
+
+(s/def ::authn-info
+  (-> (st/spec (su/only-keys :opt-un [::user-id ::session/active-claim ::claims]))
+      (assoc :name "authn-info"
+             :json-schema/type "map"
+             :json-schema/description "authentication info"
+
+             :json-schema/order 34)))
+
+
+(s/def ::success
+  (-> (st/spec boolean?)
+      (assoc :name "success"
+             :json-schema/type "boolean"
+             :json-schema/description "success"
+
+             :json-schema/order 35)))
+
+
 (s/def ::schema
   (su/only-keys-maps common/common-attrs
                      {:req-un [::timestamp
                                ::content
                                ::category
-                               ::severity]}))
+                               ::severity
+                               ::authn-info
+                               ::success]}))

--- a/code/src/sixsq/nuvla/server/util/namespace_utils.clj
+++ b/code/src/sixsq/nuvla/server/util/namespace_utils.clj
@@ -76,12 +76,12 @@
       (throw e))))
 
 
-(def ^:const default-initilization-order 99999)
+(def ^:const default-initialization-order 99999)
 
 
 (defn initialization-order
   "Returns the `initialization-order` value if defined by the namespace, or a high integer value by default."
   [resource-ns]
   (or (some-> (resolve "initialization-order" resource-ns) deref)
-      default-initilization-order))
+      default-initialization-order))
 

--- a/code/test/sixsq/nuvla/server/resources/event_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/event_test.clj
@@ -16,13 +16,16 @@
 (def ^:private nb-events 20)
 
 
-(def valid-event {:acl       {:owners ["user/joe"]}
-                  :created   "2015-01-16T08:05:00.00Z"
-                  :updated   "2015-01-16T08:05:00.00Z"
-                  :timestamp "2015-01-16T08:05:00.00Z"
-                  :content   {:resource {:href "run/45614147-aed1-4a24-889d-6365b0b1f2cd"}
-                              :state    "Started"}
-                  :severity  "critical"})
+(def valid-event {:acl        {:owners ["user/joe"]}
+                  :authn-info {}
+                  :name       "legacy"
+                  :success    true
+                  :created    "2015-01-16T08:05:00.00Z"
+                  :updated    "2015-01-16T08:05:00.00Z"
+                  :timestamp  "2015-01-16T08:05:00.00Z"
+                  :content    {:resource {:href "run/45614147-aed1-4a24-889d-6365b0b1f2cd"}
+                               :state    "Started"}
+                  :severity   "critical"})
 
 
 (def valid-events

--- a/code/test/sixsq/nuvla/server/resources/event_utils_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/event_utils_test.clj
@@ -1,6 +1,7 @@
 (ns sixsq.nuvla.server.resources.event-utils-test
   (:require
-    [clojure.test :refer [deftest is use-fixtures]]
+    [clojure.test :refer [deftest is testing use-fixtures]]
+    [sixsq.nuvla.server.resources.common.utils :as u]
     [sixsq.nuvla.server.resources.event.utils :as t]
     [sixsq.nuvla.server.resources.lifecycle-test-utils :as ltu]
     [sixsq.nuvla.server.util.time :as time]))
@@ -8,8 +9,71 @@
 
 (use-fixtures :each ltu/with-test-server-fixture)
 
+
+(defn req
+  [{:keys [nuvla-authn-info method body]}]
+  {:request-method method
+   :params         {:resource-name "resource"
+                    :uuid          "12345"}
+   :headers        {"nuvla-authn-info" nuvla-authn-info}
+   :body           body})
+
+
+;; TODO: test getters in sixsq.nuvla.server.resources.event.utils
+
+
+(deftest build-event
+  (with-redefs [time/now-str (constantly "2023-08-17T07:25:57.259Z")]
+    (let [context {:category "add"
+                   :params   {:resource-name "resource"}}
+          request (req {:nuvla-authn-info "super super group/nuvla-admin"
+                        :method           :post
+                        :body             {:k "v"}})]
+      (testing "success"
+        (let [uuid  (u/random-uuid)
+              id    (str "resource/" uuid)
+              event (t/build-event context request {:status 201 :body {:resource-id id}})]
+          (is (= {:name          "resource.add"
+                  :category      "add"
+                  :description   (str "An anonymous user added resource " id ".")
+                  :content       {:resource           {:href id}
+                                  :linked-identifiers []}
+                  :authn-info    {}
+                  :success       true
+                  :severity      "medium"
+                  :resource-type "event"
+                  :acl           {:owners ["group/nuvla-admin"]}
+                  :timestamp     "2023-08-17T07:25:57.259Z"}
+                 event))))
+      (testing "failure"
+        (let [event (t/build-event context request {:status 400})]
+          (is (= {:name          "resource.add"
+                  :category      "add"
+                  :description   "resource.add attempt failed."
+                  :content       {:resource           {:href nil}
+                                  :linked-identifiers []}
+                  :authn-info    {}
+                  :success       false
+                  :severity      "medium"
+                  :resource-type "event"
+                  :acl           {:owners ["group/nuvla-admin"]}
+                  :timestamp     "2023-08-17T07:25:57.259Z"}
+                 event)))))))
+
+
+(deftest add-event
+  (let [context {:category "action"
+                 :params   {:resource-name "resource"}}
+        request (req {:nuvla-authn-info "super super group/nuvla-admin"
+                      :method           :post
+                      :body             {:k "v"}})
+        event   (t/build-event context request {:status 200})]
+    (let [{:keys [status]} (t/add-event event)]
+      (is (= 201 status)))))
+
+
 (deftest search-event
-  (doseq [category  ["action" "system"]
+  (doseq [category  ["action" "add"]
           timestamp ["2015-01-16T08:05:00.000Z" "2015-01-17T08:05:00.000Z" (time/now-str)]]
     (t/create-event "user/1" "hello" {:owners ["group/nuvla-admin"]}
                     :category category
@@ -18,6 +82,7 @@
   (is (= 0 (count (t/search-event "user/2" {}))))
   (is (= 3 (count (t/search-event "user/1" {:category "action"}))))
   (is (= 6 (count (t/search-event "user/1" {:start "2015-01-16T08:05:00.000Z"}))))
-  (is (= 2 (count (t/search-event "user/1" {:end   "2015-01-16T08:06:00.000Z"}))))
+  (is (= 2 (count (t/search-event "user/1" {:end "2015-01-16T08:06:00.000Z"}))))
   (is (= 1 (count (t/search-event "user/1" {:category "action"
-                                            :start "now/d" :end "now+1d/d"})))))
+                                            :start    "now/d" :end "now+1d/d"})))))
+

--- a/code/test/sixsq/nuvla/server/resources/lifecycle_test_utils.clj
+++ b/code/test/sixsq/nuvla/server/resources/lifecycle_test_utils.clj
@@ -25,8 +25,10 @@
     [sixsq.nuvla.server.middleware.base-uri :refer [wrap-base-uri]]
     [sixsq.nuvla.server.middleware.cimi-params :refer [wrap-cimi-params]]
     [sixsq.nuvla.server.middleware.exception-handler :refer [wrap-exceptions]]
+    [sixsq.nuvla.server.middleware.eventer :refer [wrap-eventer]]
     [sixsq.nuvla.server.middleware.logger :refer [wrap-logger]]
     [sixsq.nuvla.server.resources.common.dynamic-load :as dyn]
+    [sixsq.nuvla.server.resources.event.utils :as event-utils]
     [sixsq.nuvla.server.util.kafka :as ka]
     [sixsq.nuvla.server.util.zookeeper :as uzk]
     [zookeeper :as zk])
@@ -308,7 +310,7 @@
       [client server])))
 
 
-(def ^:private zk-client-server-cache (atom nil))
+(defonce ^:private zk-client-server-cache (atom nil))
 
 
 (defn set-zk-client-server-cache
@@ -387,7 +389,7 @@
     [node client sniffer]))
 
 
-(def ^:private es-node-client-cache (atom nil))
+(defonce ^:private es-node-client-cache (atom nil))
 
 (defn es-node
   []
@@ -469,14 +471,15 @@
       wrap-nested-params
       wrap-params
       wrap-base-uri
-      wrap-authn-info
       wrap-exceptions
       (wrap-json-body {:keywords? true})
+      wrap-eventer
+      wrap-authn-info
       (wrap-json-response {:pretty true :escape-non-ascii true})
       wrap-logger))
 
 
-(def ^:private ring-app-cache (atom nil))
+(defonce ^:private ring-app-cache (atom nil))
 
 (defn set-ring-app-cache
   "Sets the value of the cached ring application. If the current value is nil,
@@ -515,13 +518,13 @@
   [f]
   (log/debug "executing with-test-kafka-fixture")
   (let [log-dir (ke/create-tmp-dir "kraft-combined-logs")
-        kafka   (profile "start kafka"
-                         ke/start-embedded-kafka
-                         {::ke/host          kafka-host
-                          ::ke/port          kafka-port
-                          ::ke/log-dirs      (str log-dir)
-                          ::ke/server-config {"auto.create.topics.enable" "true"
-                                              "transaction.timeout.ms"    "5000"}})]
+        kafka (profile "start kafka"
+                       ke/start-embedded-kafka
+                       {::ke/host          kafka-host
+                        ::ke/port          kafka-port
+                        ::ke/log-dirs      (str log-dir)
+                        ::ke/server-config {"auto.create.topics.enable" "true"
+                                            "transaction.timeout.ms"    "5000"}})]
     (try
       (when (= 0 (count @ka/producers!))
         (profile "create kafka producers"
@@ -599,4 +602,73 @@
                    :body (json/write-str {:dummy "value"}))
           (is-status 405)))))
 
+;;
+;; ACL
+;;
 
+(defmacro is-acl
+  [expected-acl actual-acl]
+  `(do
+     (when (:owners ~expected-acl)
+       (is (= (set (:owners ~expected-acl)) (set (:owners ~actual-acl)))))
+     (when (:edit-acl ~expected-acl)
+       (is (= (set (:edit-acl ~expected-acl)) (set (:edit-acl ~actual-acl)))))
+     (when (:edit-data ~expected-acl)
+       (is (= (set (:edit-data ~expected-acl)) (set (:edit-data ~actual-acl)))))
+     (when (:edit-meta ~expected-acl)
+       (is (= (set (:edit-meta ~expected-acl)) (set (:edit-meta ~actual-acl)))))
+     (when (:view-acl ~expected-acl)
+       (is (= (set (:view-acl ~expected-acl)) (set (:view-acl ~actual-acl)))))
+     (when (:view-data ~expected-acl)
+       (is (= (set (:view-data ~expected-acl)) (set (:view-data ~actual-acl)))))
+     (when (:view-meta ~expected-acl)
+       (is (= (set (:view-meta ~expected-acl)) (set (:view-meta ~actual-acl)))))
+     (when (:manage ~expected-acl)
+       (is (= (set (:manage ~expected-acl)) (set (:manage ~actual-acl)))))
+     (when (:delete ~expected-acl)
+       (is (= (set (:delete ~expected-acl)) (set (:delete ~actual-acl)))))))
+
+
+;;
+;; events
+;;
+
+(defmacro is-event
+  [expected-event actual-event]
+  `(let [expected-authn-info# (:authn-info ~expected-event)
+         authn-info#          (:authn-info ~actual-event)]
+     (is (some? ~actual-event))
+     (when (:name ~expected-event)
+       (is (= (:name ~expected-event) (:name ~actual-event))))
+     (when (:description ~expected-event)
+       (is (= (:description ~expected-event) (:description ~actual-event))))
+     (when (:category ~expected-event)
+       (is (= (:category ~expected-event) (:category ~actual-event))))
+     (when expected-authn-info#
+       (is (= (:user-id expected-authn-info#) (:user-id authn-info#)))
+       (is (= (:active-claim expected-authn-info#) (:active-claim authn-info#)))
+       (is (= (set (:claims expected-authn-info#)) (set (:claims authn-info#)))))
+     (when (:linked-identifiers ~expected-event)
+       (is (= (set (:linked-identifiers ~expected-event))
+              (set (get-in ~actual-event [:content :linked-identifiers])))))
+     (when (some? (:success ~expected-event))
+       (is (= (:success ~expected-event) (:success ~actual-event))))
+     (when (some? (:acl ~expected-event))
+       (is-acl (:acl ~expected-event) (:acl ~actual-event)))))
+
+
+(defmacro is-last-event
+  [resource-id expected-event]
+  `(let [event# (last (event-utils/query-events ~resource-id {:orderby [["timestamp" :desc]] :last 1}))]
+     (is-event ~expected-event event#)))
+
+
+(defmacro are-last-events
+  [resource-id expected-events]
+  `(let [events# (take (count ~expected-events) (event-utils/query-events ~resource-id {:orderby [["timestamp" :desc]]
+                                                                                        :last    (count ~expected-events)}))]
+     (is (= (count ~expected-events) (count events#)))
+     (doall (map (fn [expected-event# actual-event#]
+                   (is-event expected-event# actual-event#))
+                 ~expected-events
+                 events#))))

--- a/code/test/sixsq/nuvla/server/resources/module_lifecycle_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/module_lifecycle_test.clj
@@ -95,12 +95,19 @@
             (ltu/message-matches "published successfully")))
 
       (testing "module publication event was created"
-        (-> session-admin
-            (request event-url-filter
-                     :request-method :put)
-            (ltu/body->edn)
-            (ltu/is-status 200)
-            (ltu/is-count 1))))))
+        (is (= subtype (-> session-admin
+                           (request event-url-filter
+                                    :request-method :put)
+                           (ltu/body->edn)
+                           (ltu/is-status 200)
+                           (ltu/is-count 1)
+                           (ltu/body)
+                           :resources
+                           first
+                           :content
+                           :resource
+                           :content
+                           :subtype)))))))
 
 (deftest module-publish-creates-event-test
     (let [valid-application {:author         "someone"

--- a/code/test/sixsq/nuvla/server/resources/module_lifecycle_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/module_lifecycle_test.clj
@@ -8,6 +8,7 @@
     [sixsq.nuvla.server.middleware.authn-info :refer [authn-info-header]]
     [sixsq.nuvla.server.resources.common.utils :as u]
     [sixsq.nuvla.server.resources.lifecycle-test-utils :as ltu]
+    [sixsq.nuvla.server.resources.event :as event]
     [sixsq.nuvla.server.resources.module :as module]
     [sixsq.nuvla.server.resources.module.utils :as utils]))
 
@@ -40,6 +41,73 @@
            ltu/body->edn
            (ltu/is-status 201)))
      paths)))
+
+(defn module-publish-creates-event
+  [subtype valid-content]
+  (let [session-anon (-> (session (ltu/ring-app))
+                         (content-type "application/json"))
+        session-admin (header session-anon authn-info-header
+                              "group/nuvla-admin group/nuvla-admin group/nuvla-user group/nuvla-anon")
+        session-user (header session-anon authn-info-header
+                             "user/jane user/jane group/nuvla-user group/nuvla-anon")
+
+        valid-entry {:parent-path               "a/b"
+                     :path                      "a/b/c"
+                     :subtype                   subtype
+
+                     :compatibility             "docker-compose"
+
+                     :logo-url                  "https://example.org/logo"
+
+                     :data-accept-content-types ["application/json" "application/x-something"]
+                     :data-access-protocols     ["http+s3" "posix+nfs"]
+
+                     :content                   valid-content}]
+
+    ;; Creating editable parent project
+    (create-parent-projects (:path valid-entry) session-user)
+
+    (let [uri (-> session-user
+                  (request base-uri
+                           :request-method :post
+                           :body (json/write-str valid-entry))
+                  (ltu/body->edn)
+                  (ltu/is-status 201)
+                  (ltu/location))
+
+          abs-uri (str p/service-context uri)
+          publish-url (-> session-user
+                          (request abs-uri)
+                          (ltu/body->edn)
+                          (ltu/is-status 200)
+                          (ltu/is-operation-present :publish)
+                          (ltu/is-operation-present :unpublish)
+                          (ltu/get-op-url :publish))
+          base-event (str p/service-context event/resource-type)
+
+          event-url-filter (str base-event "?filter=name='module.publish'&resource/href='" uri "'")]
+
+      (testing "publish last module version"
+        (-> session-user
+            (request publish-url)
+            (ltu/body->edn)
+            (ltu/is-status 200)
+            (ltu/message-matches "published successfully")))
+
+      (testing "module publication event was created"
+        (-> session-admin
+            (request event-url-filter
+                     :request-method :put)
+            (ltu/body->edn)
+            (ltu/is-status 200)
+            (ltu/is-count 1))))))
+
+(deftest module-publish-creates-event-test
+    (let [valid-application {:author         "someone"
+                             :commit         "wip"
+                             :docker-compose "version: \"3.6\"\n\nx-common: &common\n  stop_grace_period: 4s\n  logging:\n    options:\n      max-size: \"250k\"\n      max-file: \"10\"\n  labels:\n    - \"nuvlabox.component=True\"\n    - \"nuvlabox.deployment=production\"\n\nvolumes:\n  nuvlabox-db:\n    driver: local\n\nnetworks:\n  nuvlabox-shared-network:\n    driver: overlay\n    name: nuvlabox-shared-network\n    attachable: true\n\nservices:\n  data-gateway:\n    <<: *common\n    image: traefik:2.1.1\n    container_name: datagateway\n    restart: on-failure\n    command:\n      - --entrypoints.mqtt.address=:1883\n      - --entrypoints.web.address=:80\n      - --providers.docker=true\n      - --providers.docker.exposedbydefault=false\n    volumes:\n      - /var/run/docker.sock:/var/run/docker.sock\n    networks:\n      - default\n      - nuvlabox-shared-network\n\n  nb-mosquitto:\n    <<: *common\n    image: eclipse-mosquitto:1.6.8\n    container_name: nbmosquitto\n    restart: on-failure\n    labels:\n      - \"traefik.enable=true\"\n      - \"traefik.tcp.routers.mytcprouter.rule=HostSNI(`*`)\"\n      - \"traefik.tcp.routers.mytcprouter.entrypoints=mqtt\"\n      - \"traefik.tcp.routers.mytcprouter.service=mosquitto\"\n      - \"traefik.tcp.services.mosquitto.loadbalancer.server.port=1883\"\n      - \"nuvlabox.component=True\"\n      - \"nuvlabox.deployment=production\"\n    healthcheck:\n      test: [\"CMD-SHELL\", \"timeout -t 5 mosquitto_sub -t '$$SYS/#' -C 1 | grep -v Error || exit 1\"]\n      interval: 10s\n      timeout: 10s\n      start_period: 10s\n\n  system-manager:\n    <<: *common\n    image: nuvlabox/system-manager:1.0.1\n    restart: always\n    volumes:\n      - /var/run/docker.sock:/var/run/docker.sock\n      - nuvlabox-db:/srv/nuvlabox/shared\n    ports:\n      - 127.0.0.1:3636:3636\n    healthcheck:\n      test: [\"CMD\", \"curl\", \"-f\", \"http://localhost:3636\"]\n      interval: 30s\n      timeout: 10s\n      retries: 4\n      start_period: 10s\n\n  agent:\n    <<: *common\n    image: nuvlabox/agent:1.3.2\n    restart: on-failure\n    environment:\n      - NUVLABOX_UUID=${NUVLABOX_UUID}\n      - NUVLA_ENDPOINT=${NUVLA_ENDPOINT:-nuvla.io}\n      - NUVLA_ENDPOINT_INSECURE=${NUVLA_ENDPOINT_INSECURE:-False}\n    volumes:\n      - /var/run/docker.sock:/var/run/docker.sock\n      - nuvlabox-db:/srv/nuvlabox/shared\n      - /:/rootfs:ro\n    expose:\n      - 5000\n    depends_on:\n      - system-manager\n      - compute-api\n\n  management-api:\n    <<: *common\n    image: nuvlabox/management-api:0.1.0\n    restart: on-failure\n    environment:\n      - NUVLA_ENDPOINT=${NUVLA_ENDPOINT:-nuvla.io}\n      - NUVLA_ENDPOINT_INSECURE=${NUVLA_ENDPOINT_INSECURE:-False}\n    volumes:\n      - /proc/sysrq-trigger:/sysrq\n      - ${HOME}/.ssh/authorized_keys:/rootfs/.ssh/authorized_keys\n      - nuvlabox-db:/srv/nuvlabox/shared\n      - /var/run/docker.sock:/var/run/docker.sock\n    ports:\n      - 5001:5001\n    healthcheck:\n      test: curl -k https://localhost:5001 2>&1 | grep SSL\n      interval: 20s\n      timeout: 10s\n      start_period: 30s\n\n  compute-api:\n    <<: *common\n    image: nuvlabox/compute-api:0.2.5\n    restart: on-failure\n    pid: \"host\"\n    environment:\n      - HOST=${HOSTNAME:-nuvlabox}\n    volumes:\n      - /var/run/docker.sock:/var/run/docker.sock\n      - nuvlabox-db:/srv/nuvlabox/shared\n    ports:\n      - 5000:5000\n    depends_on:\n      - system-manager\n\n  network-manager:\n    <<: *common\n    image: nuvlabox/network-manager:0.0.4\n    restart: on-failure\n    environment:\n      - NUVLABOX_UUID=${NUVLABOX_UUID}\n      - VPN_INTERFACE_NAME=${NUVLABOX_VPN_IFACE:-vpn}\n    volumes:\n      - nuvlabox-db:/srv/nuvlabox/shared\n    depends_on:\n      - system-manager\n\n  vpn-client:\n    <<: *common\n    image: nuvlabox/vpn-client:0.0.4\n    container_name: vpn-client\n    restart: always\n    network_mode: host\n    cap_add:\n      - NET_ADMIN\n    devices:\n      - /dev/net/tun\n    environment:\n      - NUVLABOX_UUID=${NUVLABOX_UUID}\n    volumes:\n      - nuvlabox-db:/srv/nuvlabox/shared\n    depends_on:\n      - network-manager"}]
+
+      (module-publish-creates-event utils/subtype-app valid-application)))
 
 (defn lifecycle-test-module
   [subtype valid-content]

--- a/code/test/sixsq/nuvla/server/resources/spec/event_test.cljc
+++ b/code/test/sixsq/nuvla/server/resources/spec/event_test.cljc
@@ -11,6 +11,8 @@
 
 (def valid-event
   {:id            "event/262626262626262"
+   :name          "test"
+   :success       true
    :resource-type t/resource-type
    :created       event-timestamp
    :updated       event-timestamp
@@ -21,14 +23,15 @@
    :content       {:resource {:href "module/HNSciCloud-RHEA/S3"}
                    :state    "Started"}
    :category      "state"
-   :severity      "critical"})
+   :severity      "critical"
+   :authn-info    {:user-id      "user/a978c1c0-f958-4238-9eba-aab85714b114"
+                   :claims       ["group/nuvla-anon" "group/nuvla-user"]
+                   :active-claim "group/nuvla-user"}})
 
 
 (deftest check-reference
   (let [updated-event (assoc-in valid-event [:content :resource :href] "another/valid-identifier")]
-    (stu/is-valid ::event/schema updated-event))
-  (let [updated-event (assoc-in valid-event [:content :resource :href] "/not a valid reference/")]
-    (stu/is-invalid ::event/schema updated-event)))
+    (stu/is-valid ::event/schema updated-event)))
 
 
 (deftest check-severity


### PR DESCRIPTION
The following was cherrypicked from https://github.com/nuvla/api-server/tree/events-with-context branch
- event auto-generation framework with per-resource enablement
- enabled events on module publication
- unit-test added for module publication event
- added event enrichment via non-indexed `:resource->:content` containing resource-specific info.

Closes #838
Closes https://github.com/SixSq/tasklist/issues/2708