### PR TITLE
Make recompute fleet operation available on PARTIALLY_STARTED state.

### DIFF
--- a/code/src/sixsq/nuvla/server/resources/deployment_set/utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/deployment_set/utils.clj
@@ -125,7 +125,8 @@
                                    transition-stop
                                    transition-plan
                                    transition-operational-status
-                                   transition-force-delete]}
+                                   transition-force-delete
+                                   transition-recompute-fleet]}
                 {::tk/name        state-stopping
                  ::tk/transitions [(transition-cancel state-partially-stopped)
                                    (transition-nok state-partially-stopped)


### PR DESCRIPTION
Fixes SixSq/tasklist#2782
