### PR TITLE
Relax spec on resource description to allow empty strings.

### DIFF
--- a/code/src/sixsq/nuvla/server/resources/spec/common.cljc
+++ b/code/src/sixsq/nuvla/server/resources/spec/common.cljc
@@ -101,7 +101,7 @@
 
 
 (s/def ::description
-  (-> (st/spec ::core/nonblank-string)
+  (-> (st/spec string?)
       (assoc :name "description"
              :json-schema/description "human-readable description of resource"
              :json-schema/section "meta"


### PR DESCRIPTION
Fixes SixSq/tasklist#2857
