### PR TITLE
As a Nuvla API admin user, I want NuvlaEdge status updates to be automatically reflected into NuvlaEdge metrics, so that the NuvlaEdge metrics time-series is fed in near real-time

### DIFF
--- a/code/src/sixsq/nuvla/server/resources/nuvlabox/status_utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/nuvlabox/status_utils.clj
@@ -127,8 +127,10 @@
 
 (defn nuvlabox-status->ts-bulk-insert-request
   [response]
-  {:headers     {"bulk" true}
-   :params      {:resource-name ts-nuvlaedge/resource-type
-                 :action        "bulk-insert"}
-   :body        (nuvlabox-status->ts-bulk-insert-request-body (:body response))
-   :nuvla/authn auth/internal-identity})
+  (let [body (nuvlabox-status->ts-bulk-insert-request-body (:body response))]
+    (when (seq body)
+      {:headers     {"bulk" true}
+       :params      {:resource-name ts-nuvlaedge/resource-type
+                     :action        "bulk-insert"}
+       :body        body
+       :nuvla/authn auth/internal-identity})))

--- a/code/src/sixsq/nuvla/server/resources/nuvlabox/status_utils.clj
+++ b/code/src/sixsq/nuvla/server/resources/nuvlabox/status_utils.clj
@@ -115,18 +115,20 @@
 
 (defn nuvlabox-status->ts-bulk-insert-request-body
   [{:keys [parent current-time] :as nuvlabox-status}]
-  (->> [:cpu :ram :disk :network :power-consumption]
-       (map (fn [metric]
-              (->> (nuvlabox-status->metric-data nuvlabox-status metric)
-                   (map #(assoc {:nuvlaedge-id parent
-                                 :metric       (name metric)
-                                 :timestamp    current-time}
-                           metric %)))))
-       (apply concat)))
+  (when current-time
+    (->> [:cpu :ram :disk :network :power-consumption]
+         (map (fn [metric]
+                (->> (nuvlabox-status->metric-data nuvlabox-status metric)
+                     (map #(assoc {:nuvlaedge-id parent
+                                   :metric       (name metric)
+                                   :timestamp    current-time}
+                             metric %)))))
+         (apply concat))))
 
 (defn nuvlabox-status->ts-bulk-insert-request
   [response]
-  {:params      {:resource-name ts-nuvlaedge/resource-type
+  {:headers     {"bulk" true}
+   :params      {:resource-name ts-nuvlaedge/resource-type
                  :action        "bulk-insert"}
    :body        (nuvlabox-status->ts-bulk-insert-request-body (:body response))
    :nuvla/authn auth/internal-identity})

--- a/code/src/sixsq/nuvla/server/resources/nuvlabox_status.clj
+++ b/code/src/sixsq/nuvla/server/resources/nuvlabox_status.clj
@@ -106,7 +106,8 @@ Versioned subclasses define the attributes for a particular NuvlaBox release.
 
 (defn bulk-insert-metrics
   [response]
-  (crud/bulk-action (utils/nuvlabox-status->ts-bulk-insert-request response)))
+  (some-> (utils/nuvlabox-status->ts-bulk-insert-request response)
+          (crud/bulk-action)))
 
 (defn post-edit
   [response request]

--- a/code/src/sixsq/nuvla/server/resources/nuvlabox_status.clj
+++ b/code/src/sixsq/nuvla/server/resources/nuvlabox_status.clj
@@ -104,12 +104,16 @@ Versioned subclasses define the attributes for a particular NuvlaBox release.
         (cond-> (some? resources-prev)
                 (assoc :resources-prev resources-prev)))))
 
+(defn bulk-insert-metrics
+  [response]
+  (crud/bulk-action (utils/nuvlabox-status->ts-bulk-insert-request response)))
+
 (defn post-edit
   [response request]
   (utils/denormalize-changes-nuvlabox (r/response-body response))
   (utils/detect-swarm response request)
   (kafka-crud/publish-on-edit resource-type response)
-  #_(crud/add (utils/nuvlabox-status->ts-add-request response))
+  (bulk-insert-metrics response)
   (utils/special-body-nuvlabox response request))
 
 (defn pre-validate-hook

--- a/code/test/sixsq/nuvla/server/resources/nuvlabox/status_utils_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/nuvlabox/status_utils_test.clj
@@ -39,119 +39,119 @@
                                        :inferred-location       [46.2 6.1]
                                        :nuvlabox-engine-version "2.0.0"}))))
 
-(deftest nuvlabox-status->ts-bulk-insert-request-body
-  (testing "nuvlabox status -> metric time-series conversion"
-    (let [nuvlaedge-id    "nuvlabox/1"
-          sampling-time   "2023-05-10T08:13:17Z"
-          nuvlabox-status {:id            "nuvlabox-status/f17b6239-44a9-41a1-b732-43ba11cc1af2",
-                           :resource-type "nuvlabox-status",
-                           :parent        nuvlaedge-id,
-                           :current-time  sampling-time,
-                           :updated       "2023-05-10T08:18:17.636Z",
-                           :created       "2022-01-10T15:56:39.017Z",
-                           :resources     {:cpu               {:load                0.45,
-                                                               :system-calls        0,
-                                                               :capacity            4,
-                                                               :interrupts          5667887,
-                                                               :topic               "cpu",
-                                                               :software-interrupts 4721525,
-                                                               :raw-sample          "{\"capacity\": 4, \"load\": 0.45, \"load-1\": 0.29, \"load-5\": 0.33, \"context-switches\": 18627865, \"interrupts\": 5667887, \"software-interrupts\": 4721525, \"system-calls\": 0}",
-                                                               :load-5              0.33,
-                                                               :context-switches    18627865,
-                                                               :load-1              0.29},
-                                           :ram               {:topic      "ram",
-                                                               :raw-sample "{\"capacity\": 32076, \"used\": 6445}",
-                                                               :capacity   32076,
-                                                               :used       6445},
-                                           :disks             [{:device     "sda1",
-                                                                :capacity   4,
-                                                                :used       2,
-                                                                :topic      "disks",
-                                                                :raw-sample "{\"device\": \"sda1\", \"capacity\": 4, \"used\": 2}"}
-                                                               {:device     "sda2",
-                                                                :capacity   2,
-                                                                :used       0,
-                                                                :topic      "disks",
-                                                                :raw-sample "{\"device\": \"sda2\", \"capacity\": 2, \"used\": 0}"}],
-                                           :net-stats         [{:interface         "enp0s31f6",
-                                                                :bytes-transmitted 49143,
-                                                                :bytes-received    260519}
-                                                               {:interface         "vpn",
-                                                                :bytes-transmitted 1051424260,
-                                                                :bytes-received    142997340}
-                                                               {:interface         "vethd2e8653",
-                                                                :bytes-transmitted 1862,
-                                                                :bytes-received    1848}
-                                                               {:interface         "br_LAN",
-                                                                :bytes-transmitted 55559,
-                                                                :bytes-received    244881}]
-                                           :power-consumption [{:metric-name "CPU_current", :energy-consumption 112, :unit "mA"}
-                                                               {:metric-name "CPU_voltage", :energy-consumption 19296, :unit "mV"}
-                                                               {:metric-name "CPU_power", :energy-consumption 2161, :unit "mW"}]}}]
-      (is (= [{:nuvlaedge-id nuvlaedge-id
-               :metric       "cpu"
-               :timestamp    sampling-time
-               :cpu          {:capacity            4,
-                              :load                0.45,
-                              :load-1              0.29,
-                              :load-5              0.33,
-                              :context-switches    18627865,
-                              :interrupts          5667887,
-                              :software-interrupts 4721525,
-                              :system-calls        0}}
-              {:nuvlaedge-id nuvlaedge-id
-               :metric       "ram"
-               :timestamp    sampling-time
-               :ram          {:capacity 32076,
-                              :used     6445}}
-              {:nuvlaedge-id nuvlaedge-id
-               :metric       "disk"
-               :timestamp    sampling-time
-               :disk         {:device   "sda1",
-                              :capacity 4,
-                              :used     2}}
-              {:nuvlaedge-id nuvlaedge-id
-               :metric       "disk"
-               :timestamp    sampling-time
-               :disk         {:device   "sda2",
-                              :capacity 2,
-                              :used     0}}
-              {:nuvlaedge-id nuvlaedge-id
-               :metric       "network"
-               :timestamp    sampling-time
-               :network      {:interface         "enp0s31f6",
-                              :bytes-transmitted 49143,
-                              :bytes-received    260519}}
-              {:nuvlaedge-id nuvlaedge-id
-               :metric       "network"
-               :timestamp    sampling-time
-               :network      {:interface         "vpn",
-                              :bytes-transmitted 1051424260,
-                              :bytes-received    142997340}}
-              {:nuvlaedge-id nuvlaedge-id
-               :metric       "network"
-               :timestamp    sampling-time
-               :network      {:interface         "vethd2e8653",
-                              :bytes-transmitted 1862,
-                              :bytes-received    1848}}
-              {:nuvlaedge-id nuvlaedge-id
-               :metric       "network"
-               :timestamp    sampling-time
-               :network      {:interface         "br_LAN",
-                              :bytes-transmitted 55559,
-                              :bytes-received    244881}}
-              {:nuvlaedge-id      nuvlaedge-id
-               :metric            "power-consumption"
-               :timestamp         sampling-time
-               :power-consumption {:metric-name "CPU_current", :energy-consumption 112, :unit "mA"}}
-              {:nuvlaedge-id      nuvlaedge-id
-               :metric            "power-consumption"
-               :timestamp         sampling-time
-               :power-consumption {:metric-name "CPU_voltage", :energy-consumption 19296, :unit "mV"}}
-              {:nuvlaedge-id      nuvlaedge-id
-               :metric            "power-consumption"
-               :timestamp         sampling-time
-               :power-consumption {:metric-name "CPU_power", :energy-consumption 2161, :unit "mW"}}]
-             (vec (t/nuvlabox-status->ts-bulk-insert-request-body nuvlabox-status)))))))
-
+(deftest nuvlabox-status->ts-bulk-insert
+  (let [nuvlaedge-id                      "nuvlabox/1"
+        sampling-time                     "2023-05-10T08:13:17Z"
+        nuvlabox-status                   {:id            "nuvlabox-status/f17b6239-44a9-41a1-b732-43ba11cc1af2",
+                                           :resource-type "nuvlabox-status",
+                                           :parent        nuvlaedge-id,
+                                           :current-time  sampling-time,
+                                           :updated       "2023-05-10T08:18:17.636Z",
+                                           :created       "2022-01-10T15:56:39.017Z",
+                                           :resources     {:cpu               {:load                0.45,
+                                                                               :system-calls        0,
+                                                                               :capacity            4,
+                                                                               :interrupts          5667887,
+                                                                               :topic               "cpu",
+                                                                               :software-interrupts 4721525,
+                                                                               :raw-sample          "{\"capacity\": 4, \"load\": 0.45, \"load-1\": 0.29, \"load-5\": 0.33, \"context-switches\": 18627865, \"interrupts\": 5667887, \"software-interrupts\": 4721525, \"system-calls\": 0}",
+                                                                               :load-5              0.33,
+                                                                               :context-switches    18627865,
+                                                                               :load-1              0.29},
+                                                           :ram               {:topic      "ram",
+                                                                               :raw-sample "{\"capacity\": 32076, \"used\": 6445}",
+                                                                               :capacity   32076,
+                                                                               :used       6445},
+                                                           :disks             [{:device     "sda1",
+                                                                                :capacity   4,
+                                                                                :used       2,
+                                                                                :topic      "disks",
+                                                                                :raw-sample "{\"device\": \"sda1\", \"capacity\": 4, \"used\": 2}"}
+                                                                               {:device     "sda2",
+                                                                                :capacity   2,
+                                                                                :used       0,
+                                                                                :topic      "disks",
+                                                                                :raw-sample "{\"device\": \"sda2\", \"capacity\": 2, \"used\": 0}"}],
+                                                           :net-stats         [{:interface         "enp0s31f6",
+                                                                                :bytes-transmitted 49143,
+                                                                                :bytes-received    260519}
+                                                                               {:interface         "vpn",
+                                                                                :bytes-transmitted 1051424260,
+                                                                                :bytes-received    142997340}
+                                                                               {:interface         "vethd2e8653",
+                                                                                :bytes-transmitted 1862,
+                                                                                :bytes-received    1848}
+                                                                               {:interface         "br_LAN",
+                                                                                :bytes-transmitted 55559,
+                                                                                :bytes-received    244881}]
+                                                           :power-consumption [{:metric-name "CPU_current", :energy-consumption 112, :unit "mA"}
+                                                                               {:metric-name "CPU_voltage", :energy-consumption 19296, :unit "mV"}
+                                                                               {:metric-name "CPU_power", :energy-consumption 2161, :unit "mW"}]}}
+        expected-bulk-insert-request-body [{:nuvlaedge-id nuvlaedge-id
+                                            :metric       "cpu"
+                                            :timestamp    sampling-time
+                                            :cpu          {:capacity            4,
+                                                           :load                0.45,
+                                                           :load-1              0.29,
+                                                           :load-5              0.33,
+                                                           :context-switches    18627865,
+                                                           :interrupts          5667887,
+                                                           :software-interrupts 4721525,
+                                                           :system-calls        0}}
+                                           {:nuvlaedge-id nuvlaedge-id
+                                            :metric       "ram"
+                                            :timestamp    sampling-time
+                                            :ram          {:capacity 32076,
+                                                           :used     6445}}
+                                           {:nuvlaedge-id nuvlaedge-id
+                                            :metric       "disk"
+                                            :timestamp    sampling-time
+                                            :disk         {:device   "sda1",
+                                                           :capacity 4,
+                                                           :used     2}}
+                                           {:nuvlaedge-id nuvlaedge-id
+                                            :metric       "disk"
+                                            :timestamp    sampling-time
+                                            :disk         {:device   "sda2",
+                                                           :capacity 2,
+                                                           :used     0}}
+                                           {:nuvlaedge-id nuvlaedge-id
+                                            :metric       "network"
+                                            :timestamp    sampling-time
+                                            :network      {:interface         "enp0s31f6",
+                                                           :bytes-transmitted 49143,
+                                                           :bytes-received    260519}}
+                                           {:nuvlaedge-id nuvlaedge-id
+                                            :metric       "network"
+                                            :timestamp    sampling-time
+                                            :network      {:interface         "vpn",
+                                                           :bytes-transmitted 1051424260,
+                                                           :bytes-received    142997340}}
+                                           {:nuvlaedge-id nuvlaedge-id
+                                            :metric       "network"
+                                            :timestamp    sampling-time
+                                            :network      {:interface         "vethd2e8653",
+                                                           :bytes-transmitted 1862,
+                                                           :bytes-received    1848}}
+                                           {:nuvlaedge-id nuvlaedge-id
+                                            :metric       "network"
+                                            :timestamp    sampling-time
+                                            :network      {:interface         "br_LAN",
+                                                           :bytes-transmitted 55559,
+                                                           :bytes-received    244881}}
+                                           {:nuvlaedge-id      nuvlaedge-id
+                                            :metric            "power-consumption"
+                                            :timestamp         sampling-time
+                                            :power-consumption {:metric-name "CPU_current", :energy-consumption 112, :unit "mA"}}
+                                           {:nuvlaedge-id      nuvlaedge-id
+                                            :metric            "power-consumption"
+                                            :timestamp         sampling-time
+                                            :power-consumption {:metric-name "CPU_voltage", :energy-consumption 19296, :unit "mV"}}
+                                           {:nuvlaedge-id      nuvlaedge-id
+                                            :metric            "power-consumption"
+                                            :timestamp         sampling-time
+                                            :power-consumption {:metric-name "CPU_power", :energy-consumption 2161, :unit "mW"}}]
+        bulk-insert-request-body          (t/nuvlabox-status->ts-bulk-insert-request-body nuvlabox-status)]
+    (testing "nuvlabox status -> metric time-serie conversion"
+      (is (= expected-bulk-insert-request-body (vec bulk-insert-request-body))))))
 

--- a/code/test/sixsq/nuvla/server/resources/nuvlabox/status_utils_test.clj
+++ b/code/test/sixsq/nuvla/server/resources/nuvlabox/status_utils_test.clj
@@ -38,3 +38,120 @@
       (t/denormalize-changes-nuvlabox {:online                  true
                                        :inferred-location       [46.2 6.1]
                                        :nuvlabox-engine-version "2.0.0"}))))
+
+(deftest nuvlabox-status->ts-bulk-insert-request-body
+  (testing "nuvlabox status -> metric time-series conversion"
+    (let [nuvlaedge-id    "nuvlabox/1"
+          sampling-time   "2023-05-10T08:13:17Z"
+          nuvlabox-status {:id            "nuvlabox-status/f17b6239-44a9-41a1-b732-43ba11cc1af2",
+                           :resource-type "nuvlabox-status",
+                           :parent        nuvlaedge-id,
+                           :current-time  sampling-time,
+                           :updated       "2023-05-10T08:18:17.636Z",
+                           :created       "2022-01-10T15:56:39.017Z",
+                           :resources     {:cpu               {:load                0.45,
+                                                               :system-calls        0,
+                                                               :capacity            4,
+                                                               :interrupts          5667887,
+                                                               :topic               "cpu",
+                                                               :software-interrupts 4721525,
+                                                               :raw-sample          "{\"capacity\": 4, \"load\": 0.45, \"load-1\": 0.29, \"load-5\": 0.33, \"context-switches\": 18627865, \"interrupts\": 5667887, \"software-interrupts\": 4721525, \"system-calls\": 0}",
+                                                               :load-5              0.33,
+                                                               :context-switches    18627865,
+                                                               :load-1              0.29},
+                                           :ram               {:topic      "ram",
+                                                               :raw-sample "{\"capacity\": 32076, \"used\": 6445}",
+                                                               :capacity   32076,
+                                                               :used       6445},
+                                           :disks             [{:device     "sda1",
+                                                                :capacity   4,
+                                                                :used       2,
+                                                                :topic      "disks",
+                                                                :raw-sample "{\"device\": \"sda1\", \"capacity\": 4, \"used\": 2}"}
+                                                               {:device     "sda2",
+                                                                :capacity   2,
+                                                                :used       0,
+                                                                :topic      "disks",
+                                                                :raw-sample "{\"device\": \"sda2\", \"capacity\": 2, \"used\": 0}"}],
+                                           :net-stats         [{:interface         "enp0s31f6",
+                                                                :bytes-transmitted 49143,
+                                                                :bytes-received    260519}
+                                                               {:interface         "vpn",
+                                                                :bytes-transmitted 1051424260,
+                                                                :bytes-received    142997340}
+                                                               {:interface         "vethd2e8653",
+                                                                :bytes-transmitted 1862,
+                                                                :bytes-received    1848}
+                                                               {:interface         "br_LAN",
+                                                                :bytes-transmitted 55559,
+                                                                :bytes-received    244881}]
+                                           :power-consumption [{:metric-name "CPU_current", :energy-consumption 112, :unit "mA"}
+                                                               {:metric-name "CPU_voltage", :energy-consumption 19296, :unit "mV"}
+                                                               {:metric-name "CPU_power", :energy-consumption 2161, :unit "mW"}]}}]
+      (is (= [{:nuvlaedge-id nuvlaedge-id
+               :metric       "cpu"
+               :timestamp    sampling-time
+               :cpu          {:capacity            4,
+                              :load                0.45,
+                              :load-1              0.29,
+                              :load-5              0.33,
+                              :context-switches    18627865,
+                              :interrupts          5667887,
+                              :software-interrupts 4721525,
+                              :system-calls        0}}
+              {:nuvlaedge-id nuvlaedge-id
+               :metric       "ram"
+               :timestamp    sampling-time
+               :ram          {:capacity 32076,
+                              :used     6445}}
+              {:nuvlaedge-id nuvlaedge-id
+               :metric       "disk"
+               :timestamp    sampling-time
+               :disk         {:device   "sda1",
+                              :capacity 4,
+                              :used     2}}
+              {:nuvlaedge-id nuvlaedge-id
+               :metric       "disk"
+               :timestamp    sampling-time
+               :disk         {:device   "sda2",
+                              :capacity 2,
+                              :used     0}}
+              {:nuvlaedge-id nuvlaedge-id
+               :metric       "network"
+               :timestamp    sampling-time
+               :network      {:interface         "enp0s31f6",
+                              :bytes-transmitted 49143,
+                              :bytes-received    260519}}
+              {:nuvlaedge-id nuvlaedge-id
+               :metric       "network"
+               :timestamp    sampling-time
+               :network      {:interface         "vpn",
+                              :bytes-transmitted 1051424260,
+                              :bytes-received    142997340}}
+              {:nuvlaedge-id nuvlaedge-id
+               :metric       "network"
+               :timestamp    sampling-time
+               :network      {:interface         "vethd2e8653",
+                              :bytes-transmitted 1862,
+                              :bytes-received    1848}}
+              {:nuvlaedge-id nuvlaedge-id
+               :metric       "network"
+               :timestamp    sampling-time
+               :network      {:interface         "br_LAN",
+                              :bytes-transmitted 55559,
+                              :bytes-received    244881}}
+              {:nuvlaedge-id      nuvlaedge-id
+               :metric            "power-consumption"
+               :timestamp         sampling-time
+               :power-consumption {:metric-name "CPU_current", :energy-consumption 112, :unit "mA"}}
+              {:nuvlaedge-id      nuvlaedge-id
+               :metric            "power-consumption"
+               :timestamp         sampling-time
+               :power-consumption {:metric-name "CPU_voltage", :energy-consumption 19296, :unit "mV"}}
+              {:nuvlaedge-id      nuvlaedge-id
+               :metric            "power-consumption"
+               :timestamp         sampling-time
+               :power-consumption {:metric-name "CPU_power", :energy-consumption 2161, :unit "mW"}}]
+             (vec (t/nuvlabox-status->ts-bulk-insert-request-body nuvlabox-status)))))))
+
+


### PR DESCRIPTION
Closes SixSq/tasklist#2900
