### PR TITLE
feat(App Bouquets): Copy first apps set subtype to module top level field apps-set-subtype

### DIFF
--- a/code/src/com/sixsq/nuvla/server/resources/module.clj
+++ b/code/src/com/sixsq/nuvla/server/resources/module.clj
@@ -186,6 +186,14 @@ component, or application.
       (add-version module content-href))
     module))
 
+(defn add-apps-set-subtype
+  [{:keys [subtype] :as module}]
+  (if (= module/subtype-apps-sets subtype)
+    (if-let [first-apps-set-subtype (get-in module [:content :applications-sets 0 :subtype])]
+      (assoc module :apps-set-subtype first-apps-set-subtype)
+      module)
+    module))
+
 (defn throw-cannot-access-registries-or-creds
   [request]
   (-> request
@@ -203,6 +211,7 @@ component, or application.
                (dissoc :parent-path :published :versions)
                utils/set-parent-path
                create-content
+               add-apps-set-subtype
                (dissoc :content)
                (utils/set-price nil request))))
 
@@ -277,6 +286,7 @@ component, or application.
                        existing-module [:parent-path :published :versions :subtype])
                      utils/set-parent-path
                      create-content
+                     add-apps-set-subtype
                      (dissoc :content)
                      (utils/set-price existing-module request))))))
 

--- a/code/src/com/sixsq/nuvla/server/resources/spec/module.cljc
+++ b/code/src/com/sixsq/nuvla/server/resources/spec/module.cljc
@@ -289,6 +289,12 @@
              :json-schema/type "map"
              :json-schema/order 39)))
 
+(s/def ::apps-set-subtype
+  (-> (st/spec #{"docker" "kubernetes"})
+      (assoc :name "apps-set-subtype"
+             :json-schema/type "string"
+             :json-schema/value-scope {:values ["docker" "kubernetes"]}
+             :json-schema/description "subtype of the first applications set")))
 
 (def module-keys-spec (su/merge-keys-specs [common/common-attrs
                                             {:req-un [::path
@@ -304,7 +310,8 @@
                                                       ::validation-message
                                                       ::price
                                                       ::license
-                                                      ::published]}]))
+                                                      ::published
+                                                      ::apps-set-subtype]}]))
 
 
 (s/def ::schema (su/only-keys-maps module-keys-spec))


### PR DESCRIPTION
Closes SixSq/tasklist#3474
